### PR TITLE
Added support for Gaomon M106K tablet.

### DIFF
--- a/hid-uclogic.c
+++ b/hid-uclogic.c
@@ -29,9 +29,10 @@ static inline s32 le24_to_cpu(const __u8* ptr)
 	return ptr[0] | (ptr[1] << 8UL) | (ptr[2] << 16UL);
 }
 
-#define UCLOGIC_RDESC_ID (0x64)
-#define UCLOGIC_HIRES_RDESC_ID (0xC8)
-#define UCLOGIC_HIRES_RDESC_LENGTH (18)
+#define UCLOGIC_PRM_STR_ID (0x64)
+#define UCLOGIC_HIRES_PRM_STR_ID (0xC8)
+#define UCLOGIC_PRM_STR_LENGTH (UCLOGIC_PRM_NUM * sizeof(__le16))
+#define UCLOGIC_HIRES_PRM_STR_LENGTH (18)
 
 /* Size of the original descriptor of WPXXXXU tablets */
 #define WPXXXXU_RDESC_ORIG_SIZE	212
@@ -966,13 +967,12 @@ static int uclogic_input_configured(struct hid_device *hdev,
  * @pbuf:	Location for the kmalloc'ed parameter array with
  * 		UCLOGIC_PRM_NUM elements.
  */
-static int uclogic_enable_tablet(struct hid_device *hdev, __u8 rdescid, __u8 **pbuf)
+static int uclogic_enable_tablet(struct hid_device *hdev, __u8 rdescid, __u8 **pbuf, size_t len)
 {
 	int rc;
 	struct usb_device *usb_dev = hid_to_usb_dev(hdev);
 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
 	__u8 *buf = NULL;
-	size_t len;
 
 	/*
 	 * Read string descriptor containing tablet parameters. The specific
@@ -980,11 +980,6 @@ static int uclogic_enable_tablet(struct hid_device *hdev, __u8 rdescid, __u8 **p
 	 * driver traffic.
 	 * NOTE: This enables fully-functional tablet mode.
 	 */
-	if (rdescid == UCLOGIC_HIRES_RDESC_ID) {
-		len = UCLOGIC_HIRES_RDESC_LENGTH;
-	} else {
-		len = UCLOGIC_PRM_NUM * sizeof(__le16);
-	}
 	buf = kmalloc(len, GFP_KERNEL);
 	if (buf == NULL) {
 		rc = -ENOMEM;
@@ -1010,23 +1005,26 @@ static int uclogic_enable_tablet(struct hid_device *hdev, __u8 rdescid, __u8 **p
 	}
 
 	drvdata->tablet_enabled = true;
-	*pbuf = buf;
-	buf = NULL;
+	if (pbuf) {
+		*pbuf = buf;
+		buf = NULL;
+	}
 	rc = 0;
 
 cleanup:
+
 	kfree(buf);
 	return rc;
 }
 
-static void uclogic_fill_placeholders(__u8* prdesc, unsigned int rsize, s32* params)
+static void uclogic_fill_placeholders(__u8* prdesc, unsigned int rsize, s32* params, size_t param_count)
 {
 	__u8 *p;
 	s32 v;
 	for (p = prdesc;
 	     p <= prdesc + rsize -4;) {
 		if (p[0] == 0xFE && p[1] == 0xED && p[2] == 0x1D &&
-		    p[3] < UCLOGIC_PH_ID_NUM) {
+		    p[3] < param_count) {
 			v = params[p[3]];
 			put_unaligned(cpu_to_le32(v), (s32 *)p);
 			p += 4;
@@ -1056,11 +1054,10 @@ static int uclogic_probe_tablet(struct hid_device *hdev,
 	s32 resolution;
 
 	/* Enable tablet mode and get raw device parameters */
-	rc = uclogic_enable_tablet(hdev, UCLOGIC_RDESC_ID, &bbuf);
+	rc = uclogic_enable_tablet(hdev, UCLOGIC_PRM_STR_ID, &bbuf, UCLOGIC_PRM_STR_LENGTH);
 	if (rc != 0) {
 		goto cleanup;
 	}
-
 	buf = (__le16*)bbuf;
 
 	/* Extract device parameters */
@@ -1091,7 +1088,7 @@ static int uclogic_probe_tablet(struct hid_device *hdev,
 
 	/* Format fixed report descriptor */
 	memcpy(drvdata->rdesc, rdesc_template_ptr, drvdata->rsize);
-	uclogic_fill_placeholders(drvdata->rdesc, drvdata->rsize, params);
+	uclogic_fill_placeholders(drvdata->rdesc, drvdata->rsize, params, sizeof(params)/sizeof(*params));
 
 	rc = 0;
 
@@ -1111,7 +1108,7 @@ static int uclogic_probe_tablet_hires(struct hid_device *hdev,
 	s32 resolution;
 
 	/* Enable tablet mode and get raw device parameters */
-	rc = uclogic_enable_tablet(hdev, UCLOGIC_HIRES_RDESC_ID, &buf);
+	rc = uclogic_enable_tablet(hdev, UCLOGIC_HIRES_PRM_STR_ID, &buf, UCLOGIC_HIRES_PRM_STR_LENGTH);
 	if (rc != 0) {
 		goto cleanup;
 	}
@@ -1143,8 +1140,7 @@ static int uclogic_probe_tablet_hires(struct hid_device *hdev,
 
 	/* Format fixed report descriptor */
 	memcpy(drvdata->rdesc, rdesc_template_ptr, drvdata->rsize);
-	uclogic_fill_placeholders(drvdata->rdesc, drvdata->rsize, params);
-
+	uclogic_fill_placeholders(drvdata->rdesc, drvdata->rsize, params, sizeof(params)/sizeof(*params));
 	rc = 0;
 
 cleanup:
@@ -1271,7 +1267,7 @@ static int uclogic_probe(struct hid_device *hdev,
 					uclogic_tablet_hires_rdesc_template,
 					sizeof(uclogic_tablet_hires_rdesc_template));
 			drvdata->is_hires = !rc;
-			if (rc) {
+			if (!drvdata->is_hires) {
 				rc = uclogic_probe_tablet(
 						hdev,
 						uclogic_tablet_rdesc_template,
@@ -1388,12 +1384,12 @@ static int uclogic_resume(struct hid_device *hdev)
 
 	/* Re-enable tablet, if needed */
 	if (drvdata->tablet_enabled) {
-		__u8 *buf = NULL;
-		if (drvdata->is_hires)
-			rc = uclogic_enable_tablet(hdev, UCLOGIC_HIRES_RDESC_ID, &buf);
-		else
-			rc = uclogic_enable_tablet(hdev, UCLOGIC_RDESC_ID, &buf);
-		kfree(buf);
+		if (drvdata->is_hires) {
+			rc = uclogic_enable_tablet(hdev, UCLOGIC_HIRES_PRM_STR_ID, NULL, UCLOGIC_HIRES_PRM_STR_LENGTH);
+		}
+		else {
+			rc = uclogic_enable_tablet(hdev, UCLOGIC_PRM_STR_ID, NULL, UCLOGIC_PRM_STR_LENGTH);
+		}
 		if (rc != 0) {
 			return rc;
 		}

--- a/hid-uclogic.c
+++ b/hid-uclogic.c
@@ -24,6 +24,15 @@
 #include "compat.h"
 #include <linux/version.h>
 
+static inline s32 le24_to_cpu(const __u8* ptr)
+{
+	return ptr[0] | (ptr[1] << 8UL) | (ptr[2] << 16UL);
+}
+
+#define UCLOGIC_RDESC_ID (0x64)
+#define UCLOGIC_HIRES_RDESC_ID (0xC8)
+#define UCLOGIC_HIRES_RDESC_LENGTH (18)
+
 /* Size of the original descriptor of WPXXXXU tablets */
 #define WPXXXXU_RDESC_ORIG_SIZE	212
 
@@ -544,6 +553,7 @@ enum uclogic_ph_id {
 /* Report descriptor template placeholder */
 #define UCLOGIC_PH(_ID) UCLOGIC_PH_HEAD, UCLOGIC_PH_ID_##_ID
 #define UCLOGIC_PEN_REPORT_ID	0x07
+#define UCLOGIC_HIRES_PEN_REPORT_ID	0x08
 
 /* Fixed report descriptor template */
 static const __u8 uclogic_tablet_rdesc_template[] = {
@@ -587,6 +597,55 @@ static const __u8 uclogic_tablet_rdesc_template[] = {
 	0x09, 0x30,             /*          Usage (Tip Pressure),           */
 	0x27,
 	UCLOGIC_PH(PRESSURE_LM),/*          Logical Maximum (PLACEHOLDER),  */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0xC0,                   /*      End Collection,                     */
+	0xC0                    /*  End Collection                          */
+};
+
+/* Fixed report descriptor template */
+static const __u8 uclogic_tablet_hires_rdesc_template[] = {
+	0x05, 0x0D,             /*  Usage Page (Digitizer),                 */
+	0x09, 0x02,             /*  Usage (Pen),                            */
+	0xA1, 0x01,             /*  Collection (Application),               */
+	0x85, 0x08,             /*      Report ID (8),                      */
+	0x09, 0x20,             /*      Usage (Stylus),                     */
+	0xA0,                   /*      Collection (Physical),              */
+	0x14,                   /*          Logical Minimum (0),            */
+	0x25, 0x01,             /*          Logical Maximum (1),            */
+	0x75, 0x01,             /*          Report Size (1),                */
+	0x09, 0x42,             /*          Usage (Tip Switch),             */
+	0x09, 0x44,             /*          Usage (Barrel Switch),          */
+	0x09, 0x46,             /*          Usage (Tablet Pick),            */
+	0x95, 0x03,             /*          Report Count (3),               */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0x95, 0x03,             /*          Report Count (3),               */
+	0x81, 0x03,             /*          Input (Constant, Variable),     */
+	0x09, 0x32,             /*          Usage (In Range),               */
+	0x95, 0x01,             /*          Report Count (1),               */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0x95, 0x01,             /*          Report Count (1),               */
+	0x81, 0x03,             /*          Input (Constant, Variable),     */
+	0x75, 0x10,             /*          Report Size (16),               */
+	0x95, 0x01,             /*          Report Count (1),               */
+	0xA4,                   /*          Push,                           */
+	0x05, 0x01,             /*          Usage Page (Desktop),           */
+	0x65, 0x13,             /*          Unit (Inch),                    */
+	0x55, 0xFD,             /*          Unit Exponent (-3),             */
+	0x34,                   /*          Physical Minimum (0),           */
+	0x09, 0x30,             /*          Usage (X),                      */
+	0x27, UCLOGIC_PH(X_LM), /*          Logical Maximum (PLACEHOLDER),  */
+	0x47, UCLOGIC_PH(X_PM), /*          Physical Maximum (PLACEHOLDER), */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0x09, 0x31,             /*          Usage (Y),                      */
+	0x27, UCLOGIC_PH(Y_LM), /*          Logical Maximum (PLACEHOLDER),  */
+	0x47, UCLOGIC_PH(Y_PM), /*          Physical Maximum (PLACEHOLDER), */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0xB4,                   /*          Pop,                            */
+	0x09, 0x30,             /*          Usage (Tip Pressure),           */
+	0x27,
+	UCLOGIC_PH(PRESSURE_LM),/*          Logical Maximum (PLACEHOLDER),  */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0x95, 0x02,             /*          Report Count (2),               */
 	0x81, 0x02,             /*          Input (Variable),               */
 	0xC0,                   /*      End Collection,                     */
 	0xC0                    /*  End Collection                          */
@@ -724,6 +783,13 @@ enum uclogic_prm {
 	UCLOGIC_PRM_NUM
 };
 
+enum uclogic_hires_prm_offset {
+	UCLOGIC_HIRES_PRM_OFS_X_LM = 2,
+	UCLOGIC_HIRES_PRM_OFS_Y_LM = 5,
+	UCLOGIC_HIRES_PRM_OFS_PRESSURE_LM = 8,
+	UCLOGIC_HIRES_PRM_OFS_RESOLUTION = 10
+};
+
 /* Driver data */
 struct uclogic_drvdata {
 	__u8 *rdesc;
@@ -733,6 +799,7 @@ struct uclogic_drvdata {
 	bool invert_pen_inrange;
 	bool ignore_pen_usage;
 	bool has_virtual_pad_interface;
+	bool is_hires;
 };
 
 static __u8 *uclogic_report_fixup(struct hid_device *hdev, __u8 *rdesc,
@@ -899,12 +966,12 @@ static int uclogic_input_configured(struct hid_device *hdev,
  * @pbuf:	Location for the kmalloc'ed parameter array with
  * 		UCLOGIC_PRM_NUM elements.
  */
-static int uclogic_enable_tablet(struct hid_device *hdev, __le16 **pbuf)
+static int uclogic_enable_tablet(struct hid_device *hdev, __u8 rdescid, __u8 **pbuf)
 {
 	int rc;
 	struct usb_device *usb_dev = hid_to_usb_dev(hdev);
 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
-	__le16 *buf = NULL;
+	__u8 *buf = NULL;
 	size_t len;
 
 	/*
@@ -913,7 +980,11 @@ static int uclogic_enable_tablet(struct hid_device *hdev, __le16 **pbuf)
 	 * driver traffic.
 	 * NOTE: This enables fully-functional tablet mode.
 	 */
-	len = UCLOGIC_PRM_NUM * sizeof(*buf);
+	if (rdescid == UCLOGIC_HIRES_RDESC_ID) {
+		len = UCLOGIC_HIRES_RDESC_LENGTH;
+	} else {
+		len = UCLOGIC_PRM_NUM * sizeof(__le16);
+	}
 	buf = kmalloc(len, GFP_KERNEL);
 	if (buf == NULL) {
 		rc = -ENOMEM;
@@ -921,7 +992,7 @@ static int uclogic_enable_tablet(struct hid_device *hdev, __le16 **pbuf)
 	}
 	rc = usb_control_msg(usb_dev, usb_rcvctrlpipe(usb_dev, 0),
 				USB_REQ_GET_DESCRIPTOR, USB_DIR_IN,
-				(USB_DT_STRING << 8) + 0x64,
+				(USB_DT_STRING << 8) + rdescid,
 				0x0409, buf, len,
 				USB_CTRL_GET_TIMEOUT);
 	if (rc == -EPIPE) {
@@ -948,6 +1019,23 @@ cleanup:
 	return rc;
 }
 
+static void uclogic_fill_placeholders(__u8* prdesc, unsigned int rsize, s32* params)
+{
+	__u8 *p;
+	s32 v;
+	for (p = prdesc;
+	     p <= prdesc + rsize -4;) {
+		if (p[0] == 0xFE && p[1] == 0xED && p[2] == 0x1D &&
+		    p[3] < UCLOGIC_PH_ID_NUM) {
+			v = params[p[3]];
+			put_unaligned(cpu_to_le32(v), (s32 *)p);
+			p += 4;
+		} else {
+			p++;
+		}
+	}
+}
+
 /**
  * Enable fully-functional tablet mode, retrieve device parameters and
  * generate corresponding report descriptor.
@@ -962,17 +1050,18 @@ static int uclogic_probe_tablet(struct hid_device *hdev,
 {
 	int rc;
 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
+	__u8 *bbuf = NULL;
 	__le16 *buf = NULL;
 	s32 params[UCLOGIC_PH_ID_NUM];
 	s32 resolution;
-	__u8 *p;
-	s32 v;
 
 	/* Enable tablet mode and get raw device parameters */
-	rc = uclogic_enable_tablet(hdev, &buf);
+	rc = uclogic_enable_tablet(hdev, UCLOGIC_RDESC_ID, &bbuf);
 	if (rc != 0) {
 		goto cleanup;
 	}
+
+	buf = (__le16*)bbuf;
 
 	/* Extract device parameters */
 	params[UCLOGIC_PH_ID_X_LM] = le16_to_cpu(buf[UCLOGIC_PRM_X_LM]);
@@ -1002,17 +1091,59 @@ static int uclogic_probe_tablet(struct hid_device *hdev,
 
 	/* Format fixed report descriptor */
 	memcpy(drvdata->rdesc, rdesc_template_ptr, drvdata->rsize);
-	for (p = drvdata->rdesc;
-	     p <= drvdata->rdesc + drvdata->rsize - 4;) {
-		if (p[0] == 0xFE && p[1] == 0xED && p[2] == 0x1D &&
-		    p[3] < ARRAY_SIZE(params)) {
-			v = params[p[3]];
-			put_unaligned(cpu_to_le32(v), (s32 *)p);
-			p += 4;
-		} else {
-			p++;
-		}
+	uclogic_fill_placeholders(drvdata->rdesc, drvdata->rsize, params);
+
+	rc = 0;
+
+cleanup:
+	kfree(buf);
+	return rc;
+}
+
+static int uclogic_probe_tablet_hires(struct hid_device *hdev,
+				const __u8 *rdesc_template_ptr,
+				size_t rdesc_template_len)
+{
+	int rc;
+	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
+	__u8 *buf = NULL;
+	s32 params[UCLOGIC_PH_ID_NUM];
+	s32 resolution;
+
+	/* Enable tablet mode and get raw device parameters */
+	rc = uclogic_enable_tablet(hdev, UCLOGIC_HIRES_RDESC_ID, &buf);
+	if (rc != 0) {
+		goto cleanup;
 	}
+
+	/* Extract device parameters */
+	params[UCLOGIC_PH_ID_X_LM] = le24_to_cpu(buf + UCLOGIC_HIRES_PRM_OFS_X_LM);
+	params[UCLOGIC_PH_ID_Y_LM] = le24_to_cpu(buf + UCLOGIC_HIRES_PRM_OFS_Y_LM);
+	params[UCLOGIC_PH_ID_PRESSURE_LM] =	le16_to_cpu(*(__le16*)(buf + UCLOGIC_HIRES_PRM_OFS_PRESSURE_LM));
+	resolution = le16_to_cpu(*(__le16*)(buf + UCLOGIC_HIRES_PRM_OFS_RESOLUTION));
+	if (resolution == 0) {
+		params[UCLOGIC_PH_ID_X_PM] = 0;
+		params[UCLOGIC_PH_ID_Y_PM] = 0;
+	} else {
+		params[UCLOGIC_PH_ID_X_PM] = params[UCLOGIC_PH_ID_X_LM] *
+						1000 / resolution;
+		params[UCLOGIC_PH_ID_Y_PM] = params[UCLOGIC_PH_ID_Y_LM] *
+						1000 / resolution;
+	}
+
+	/* Allocate fixed report descriptor */
+	drvdata->rdesc = devm_kzalloc(&hdev->dev,
+				rdesc_template_len,
+				GFP_KERNEL);
+	if (drvdata->rdesc == NULL) {
+		rc = -ENOMEM;
+		goto cleanup;
+	}
+	drvdata->rsize = rdesc_template_len;
+
+	/* Format fixed report descriptor */
+	memcpy(drvdata->rdesc, rdesc_template_ptr, drvdata->rsize);
+	uclogic_fill_placeholders(drvdata->rdesc, drvdata->rsize, params);
 
 	rc = 0;
 
@@ -1135,10 +1266,17 @@ static int uclogic_probe(struct hid_device *hdev,
 	case USB_DEVICE_ID_UCLOGIC_UGEE_TABLET_45:
 		/* If this is the pen interface */
 		if (intf->cur_altsetting->desc.bInterfaceNumber == 0) {
-			rc = uclogic_probe_tablet(
+			rc = uclogic_probe_tablet_hires(
 					hdev,
-					uclogic_tablet_rdesc_template,
-					sizeof(uclogic_tablet_rdesc_template));
+					uclogic_tablet_hires_rdesc_template,
+					sizeof(uclogic_tablet_hires_rdesc_template));
+			drvdata->is_hires = !rc;
+			if (rc) {
+				rc = uclogic_probe_tablet(
+						hdev,
+						uclogic_tablet_rdesc_template,
+						sizeof(uclogic_tablet_rdesc_template));
+			}
 			if (rc) {
 				hid_err(hdev, "tablet enabling failed\n");
 				return rc;
@@ -1250,8 +1388,11 @@ static int uclogic_resume(struct hid_device *hdev)
 
 	/* Re-enable tablet, if needed */
 	if (drvdata->tablet_enabled) {
-		__le16 *buf = NULL;
-		rc = uclogic_enable_tablet(hdev, &buf);
+		__u8 *buf = NULL;
+		if (drvdata->is_hires)
+			rc = uclogic_enable_tablet(hdev, UCLOGIC_HIRES_RDESC_ID, &buf);
+		else
+			rc = uclogic_enable_tablet(hdev, UCLOGIC_RDESC_ID, &buf);
 		kfree(buf);
 		if (rc != 0) {
 			return rc;
@@ -1276,7 +1417,7 @@ static int uclogic_raw_event(struct hid_device *hdev, struct hid_report *report,
 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
 
 	if ((report->type == HID_INPUT_REPORT) &&
-	    (report->id == UCLOGIC_PEN_REPORT_ID) &&
+	    (report->id == UCLOGIC_PEN_REPORT_ID || report->id == UCLOGIC_HIRES_PEN_REPORT_ID) &&
 	    (size >= 2)) {
 		if (drvdata->has_virtual_pad_interface && (data[1] & 0x20))
 			/* Change to virtual frame button report ID */


### PR DESCRIPTION
I recently got a M106K and the digimend drivers didn't support it, so I added support for it. The pen position, buttons and pressure work just fine. The hardware buttons on the side seem to work as well. No idea if or how I should make the soft buttons work.

I added support for the 0xC8 (high resolution) parameter block which is now preferred for some tablets over the legacy 0x64 one, which the M106K doesn't support. The report has a somewhat different layout and a different id (8 instead of 7).

From what I can tell, the M106K is a rebranded / redesigned Huion tablet and this patch could also make the new 1060 PLUS work, as they seem to have very similar, if not identical, reports.

Please have a look. :)