### PR TITLE
WIP Add a separate tablet button descriptor for the "hires" (Huion "new") scanner

### DIFF
--- a/hid-uclogic.c
+++ b/hid-uclogic.c
@@ -24,8 +24,15 @@
 #include "compat.h"
 #include <linux/version.h>
 
+static inline s32 le24_to_cpu(const __u8* ptr)
+{
+	return ptr[0] | (ptr[1] << 8UL) | (ptr[2] << 16UL);
+}
+
 #define UCLOGIC_PRM_STR_ID 0x64
 #define UCLOGIC_PRM_STR_LENGTH (UCLOGIC_PRM_NUM * sizeof(__le16))
+#define UCLOGIC_HIRES_PRM_STR_ID 0xC8
+#define UCLOGIC_HIRES_PRM_STR_LENGTH 18
 
 /* Size of the original descriptor of WPXXXXU tablets */
 #define WPXXXXU_RDESC_ORIG_SIZE	212
@@ -546,7 +553,8 @@ enum uclogic_ph_id {
 
 /* Report descriptor template placeholder */
 #define UCLOGIC_PH(_ID) UCLOGIC_PH_HEAD, UCLOGIC_PH_ID_##_ID
-#define UCLOGIC_PEN_REPORT_ID	0x07
+#define UCLOGIC_PEN_REPORT_ID		0x07
+#define UCLOGIC_HIRES_PEN_REPORT_ID	0x08
 
 /* Fixed report descriptor template */
 static const __u8 uclogic_tablet_rdesc_template[] = {
@@ -590,6 +598,55 @@ static const __u8 uclogic_tablet_rdesc_template[] = {
 	0x09, 0x30,             /*          Usage (Tip Pressure),           */
 	0x27,
 	UCLOGIC_PH(PRESSURE_LM),/*          Logical Maximum (PLACEHOLDER),  */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0xC0,                   /*      End Collection,                     */
+	0xC0                    /*  End Collection                          */
+};
+
+/* Fixed report descriptor template */
+static const __u8 uclogic_tablet_hires_rdesc_template[] = {
+	0x05, 0x0D,             /*  Usage Page (Digitizer),                 */
+	0x09, 0x02,             /*  Usage (Pen),                            */
+	0xA1, 0x01,             /*  Collection (Application),               */
+	0x85, 0x08,             /*      Report ID (8),                      */
+	0x09, 0x20,             /*      Usage (Stylus),                     */
+	0xA0,                   /*      Collection (Physical),              */
+	0x14,                   /*          Logical Minimum (0),            */
+	0x25, 0x01,             /*          Logical Maximum (1),            */
+	0x75, 0x01,             /*          Report Size (1),                */
+	0x09, 0x42,             /*          Usage (Tip Switch),             */
+	0x09, 0x44,             /*          Usage (Barrel Switch),          */
+	0x09, 0x46,             /*          Usage (Tablet Pick),            */
+	0x95, 0x03,             /*          Report Count (3),               */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0x95, 0x03,             /*          Report Count (3),               */
+	0x81, 0x03,             /*          Input (Constant, Variable),     */
+	0x09, 0x32,             /*          Usage (In Range),               */
+	0x95, 0x01,             /*          Report Count (1),               */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0x95, 0x01,             /*          Report Count (1),               */
+	0x81, 0x03,             /*          Input (Constant, Variable),     */
+	0x75, 0x10,             /*          Report Size (16),               */
+	0x95, 0x01,             /*          Report Count (1),               */
+	0xA4,                   /*          Push,                           */
+	0x05, 0x01,             /*          Usage Page (Desktop),           */
+	0x65, 0x13,             /*          Unit (Inch),                    */
+	0x55, 0xFD,             /*          Unit Exponent (-3),             */
+	0x34,                   /*          Physical Minimum (0),           */
+	0x09, 0x30,             /*          Usage (X),                      */
+	0x27, UCLOGIC_PH(X_LM), /*          Logical Maximum (PLACEHOLDER),  */
+	0x47, UCLOGIC_PH(X_PM), /*          Physical Maximum (PLACEHOLDER), */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0x09, 0x31,             /*          Usage (Y),                      */
+	0x27, UCLOGIC_PH(Y_LM), /*          Logical Maximum (PLACEHOLDER),  */
+	0x47, UCLOGIC_PH(Y_PM), /*          Physical Maximum (PLACEHOLDER), */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0xB4,                   /*          Pop,                            */
+	0x09, 0x30,             /*          Usage (Tip Pressure),           */
+	0x27,
+	UCLOGIC_PH(PRESSURE_LM),/*          Logical Maximum (PLACEHOLDER),  */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0x95, 0x02,             /*          Report Count (2),               */
 	0x81, 0x02,             /*          Input (Variable),               */
 	0xC0,                   /*      End Collection,                     */
 	0xC0                    /*  End Collection                          */
@@ -727,6 +784,13 @@ enum uclogic_prm {
 	UCLOGIC_PRM_NUM
 };
 
+enum uclogic_hires_prm_offset {
+	UCLOGIC_HIRES_PRM_OFS_X_LM = 2,
+	UCLOGIC_HIRES_PRM_OFS_Y_LM = 5,
+	UCLOGIC_HIRES_PRM_OFS_PRESSURE_LM = 8,
+	UCLOGIC_HIRES_PRM_OFS_RESOLUTION = 10
+};
+
 /* Driver data */
 struct uclogic_drvdata {
 	__u8 *rdesc;
@@ -736,6 +800,7 @@ struct uclogic_drvdata {
 	bool invert_pen_inrange;
 	bool ignore_pen_usage;
 	bool has_virtual_pad_interface;
+	bool is_hires;
 };
 
 static __u8 *uclogic_report_fixup(struct hid_device *hdev, __u8 *rdesc,
@@ -1038,6 +1103,60 @@ cleanup:
 	return rc;
 }
 
+static int uclogic_probe_tablet_hires(struct hid_device *hdev,
+				      const __u8 *rdesc_template_ptr,
+				      size_t rdesc_template_len)
+{
+	int rc;
+	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
+	__u8 *buf = NULL;
+	s32 params[UCLOGIC_PH_ID_NUM];
+	s32 resolution;
+
+	/* Enable tablet mode and get raw device parameters */
+	rc = uclogic_enable_tablet(hdev, UCLOGIC_HIRES_PRM_STR_ID,
+				   &buf, UCLOGIC_HIRES_PRM_STR_LENGTH);
+	if (rc != 0) {
+		goto cleanup;
+	}
+
+	/* Extract device parameters */
+	params[UCLOGIC_PH_ID_X_LM] = le24_to_cpu(buf + UCLOGIC_HIRES_PRM_OFS_X_LM);
+	params[UCLOGIC_PH_ID_Y_LM] = le24_to_cpu(buf + UCLOGIC_HIRES_PRM_OFS_Y_LM);
+	params[UCLOGIC_PH_ID_PRESSURE_LM] =
+		le16_to_cpu(*(__le16*)(buf + UCLOGIC_HIRES_PRM_OFS_PRESSURE_LM));
+	resolution = le16_to_cpu(*(__le16*)(buf + UCLOGIC_HIRES_PRM_OFS_RESOLUTION));
+	if (resolution == 0) {
+		params[UCLOGIC_PH_ID_X_PM] = 0;
+		params[UCLOGIC_PH_ID_Y_PM] = 0;
+	} else {
+		params[UCLOGIC_PH_ID_X_PM] = params[UCLOGIC_PH_ID_X_LM] *
+						1000 / resolution;
+		params[UCLOGIC_PH_ID_Y_PM] = params[UCLOGIC_PH_ID_Y_LM] *
+						1000 / resolution;
+	}
+
+	/* Allocate fixed report descriptor */
+	drvdata->rdesc = devm_kzalloc(&hdev->dev,
+				rdesc_template_len,
+				GFP_KERNEL);
+	if (drvdata->rdesc == NULL) {
+		rc = -ENOMEM;
+		goto cleanup;
+	}
+	drvdata->rsize = rdesc_template_len;
+
+	/* Format fixed report descriptor */
+	memcpy(drvdata->rdesc, rdesc_template_ptr, drvdata->rsize);
+	uclogic_fill_placeholders(drvdata->rdesc, drvdata->rsize,
+				  params, sizeof(params)/sizeof(*params));
+	rc = 0;
+
+cleanup:
+	kfree(buf);
+	return rc;
+}
+
 /**
  * Enable generic button mode.
  *
@@ -1153,10 +1272,17 @@ static int uclogic_probe(struct hid_device *hdev,
 	case USB_DEVICE_ID_UCLOGIC_UGEE_TABLET_47:
 		/* If this is the pen interface */
 		if (intf->cur_altsetting->desc.bInterfaceNumber == 0) {
-			rc = uclogic_probe_tablet(
+			rc = uclogic_probe_tablet_hires(
 					hdev,
-					uclogic_tablet_rdesc_template,
-					sizeof(uclogic_tablet_rdesc_template));
+					uclogic_tablet_hires_rdesc_template,
+					sizeof(uclogic_tablet_hires_rdesc_template));
+			drvdata->is_hires = !rc;
+			if (!drvdata->is_hires) {
+				rc = uclogic_probe_tablet(
+						hdev,
+						uclogic_tablet_rdesc_template,
+						sizeof(uclogic_tablet_rdesc_template));
+			}
 			if (rc) {
 				hid_err(hdev, "tablet enabling failed\n");
 				return rc;
@@ -1268,8 +1394,15 @@ static int uclogic_resume(struct hid_device *hdev)
 
 	/* Re-enable tablet, if needed */
 	if (drvdata->tablet_enabled) {
-		rc = uclogic_enable_tablet(hdev, UCLOGIC_PRM_STR_ID,
-					   NULL, UCLOGIC_PRM_STR_LENGTH);
+		if (drvdata->is_hires) {
+			rc = uclogic_enable_tablet(
+					hdev, UCLOGIC_HIRES_PRM_STR_ID,
+					NULL, UCLOGIC_HIRES_PRM_STR_LENGTH);
+		} else {
+			rc = uclogic_enable_tablet(
+					hdev, UCLOGIC_PRM_STR_ID,
+					NULL, UCLOGIC_PRM_STR_LENGTH);
+		}
 		if (rc != 0) {
 			return rc;
 		}
@@ -1293,7 +1426,8 @@ static int uclogic_raw_event(struct hid_device *hdev, struct hid_report *report,
 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
 
 	if ((report->type == HID_INPUT_REPORT) &&
-	    (report->id == UCLOGIC_PEN_REPORT_ID) &&
+	    (report->id == UCLOGIC_PEN_REPORT_ID ||
+	     report->id == UCLOGIC_HIRES_PEN_REPORT_ID) &&
 	    (size >= 2)) {
 		if (drvdata->has_virtual_pad_interface && (data[1] & 0x20))
 			/* Change to virtual frame button report ID */

--- a/hid-uclogic.c
+++ b/hid-uclogic.c
@@ -1314,7 +1314,7 @@ static int uclogic_probe(struct hid_device *hdev,
 				sizeof(uclogic_tablet_hires_rdesc_template));
 		if (!rc) {
 			drvdata->is_hires = true;
-			drvdata->invert_pen_inrange = true;
+			drvdata->invert_pen_inrange = false;
 
 			rc = uclogic_probe_buttons(
 					hdev, uclogic_hires_buttonpad_rdesc,

--- a/hid-uclogic.c
+++ b/hid-uclogic.c
@@ -897,7 +897,8 @@ static int uclogic_input_configured(struct hid_device *hdev,
  *
  * @hdev:	HID device
  * @pbuf:	Location for the kmalloc'ed parameter array with
- * 		UCLOGIC_PRM_NUM elements.
+ * 		UCLOGIC_PRM_NUM elements, or NULL if the caller doesn't
+ *		want that data.
  * @len:	The amount of memory (in bytes) that needs to be allocated
  *		for @pbuf
  */
@@ -939,7 +940,11 @@ static int uclogic_enable_tablet(struct hid_device *hdev,
 	}
 
 	drvdata->tablet_enabled = true;
-	*pbuf = buf;
+	if (pbuf)
+		*pbuf = buf;
+	else
+		kfree(buf);
+
 	return 0;
 
 cleanup:
@@ -1260,11 +1265,8 @@ static int uclogic_resume(struct hid_device *hdev)
 
 	/* Re-enable tablet, if needed */
 	if (drvdata->tablet_enabled) {
-		__u8 *buf = NULL;
-
-		rc = uclogic_enable_tablet(hdev, &buf,
+		rc = uclogic_enable_tablet(hdev, NULL,
 					   UCLOGIC_PRM_NUM * sizeof(__le16));
-		kfree(buf);
 		if (rc != 0) {
 			return rc;
 		}

--- a/hid-uclogic.c
+++ b/hid-uclogic.c
@@ -24,6 +24,9 @@
 #include "compat.h"
 #include <linux/version.h>
 
+#define UCLOGIC_PRM_STR_ID 0x64
+#define UCLOGIC_PRM_STR_LENGTH (UCLOGIC_PRM_NUM * sizeof(__le16))
+
 /* Size of the original descriptor of WPXXXXU tablets */
 #define WPXXXXU_RDESC_ORIG_SIZE	212
 
@@ -902,7 +905,7 @@ static int uclogic_input_configured(struct hid_device *hdev,
  * @len:	The amount of memory (in bytes) that needs to be allocated
  *		for @pbuf
  */
-static int uclogic_enable_tablet(struct hid_device *hdev,
+static int uclogic_enable_tablet(struct hid_device *hdev, __u8 rdescid,
 				 __u8 **pbuf, size_t len)
 {
 	int rc;
@@ -922,7 +925,7 @@ static int uclogic_enable_tablet(struct hid_device *hdev,
 
 	rc = usb_control_msg(usb_dev, usb_rcvctrlpipe(usb_dev, 0),
 				USB_REQ_GET_DESCRIPTOR, USB_DIR_IN,
-				(USB_DT_STRING << 8) + 0x64,
+				(USB_DT_STRING << 8) + rdescid,
 				0x0409, buf, len,
 				USB_CTRL_GET_TIMEOUT);
 	if (rc == -EPIPE) {
@@ -990,8 +993,8 @@ static int uclogic_probe_tablet(struct hid_device *hdev,
 	s32 resolution;
 
 	/* Enable tablet mode and get raw device parameters */
-	rc = uclogic_enable_tablet(hdev, &bbuf,
-				   UCLOGIC_PRM_NUM * sizeof(__le16));
+	rc = uclogic_enable_tablet(hdev, UCLOGIC_PRM_STR_ID,
+				   &bbuf, UCLOGIC_PRM_STR_LENGTH);
 	if (rc != 0) {
 		goto cleanup;
 	}
@@ -1265,8 +1268,8 @@ static int uclogic_resume(struct hid_device *hdev)
 
 	/* Re-enable tablet, if needed */
 	if (drvdata->tablet_enabled) {
-		rc = uclogic_enable_tablet(hdev, NULL,
-					   UCLOGIC_PRM_NUM * sizeof(__le16));
+		rc = uclogic_enable_tablet(hdev, UCLOGIC_PRM_STR_ID,
+					   NULL, UCLOGIC_PRM_STR_LENGTH);
 		if (rc != 0) {
 			return rc;
 		}

--- a/hid-uclogic.c
+++ b/hid-uclogic.c
@@ -1203,7 +1203,9 @@ cleanup:
  *
  * @hdev:	HID device
  */
-static int uclogic_probe_buttons(struct hid_device *hdev)
+static int uclogic_probe_buttons(struct hid_device *hdev,
+				 const __u8 *buttonpad_rdesc_ptr,
+				 size_t buttonpad_rdesc_len)
 {
 	int rc;
 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
@@ -1217,7 +1219,7 @@ static int uclogic_probe_buttons(struct hid_device *hdev)
 	}
 
 	/* Re-allocate fixed report descriptor */
-	rdesc_len = drvdata->rsize + sizeof(uclogic_buttonpad_rdesc);
+	rdesc_len = drvdata->rsize + buttonpad_rdesc_len;
 	rdesc = devm_kzalloc(&hdev->dev, rdesc_len, GFP_KERNEL);
 	if (!rdesc) {
 		rc = -ENOMEM;
@@ -1227,8 +1229,8 @@ static int uclogic_probe_buttons(struct hid_device *hdev)
 	memcpy(rdesc, drvdata->rdesc, drvdata->rsize);
 
 	/* Append the buttonpad descriptor */
-	memcpy(rdesc + drvdata->rsize, uclogic_buttonpad_rdesc,
-	       sizeof(uclogic_buttonpad_rdesc));
+	memcpy(rdesc + drvdata->rsize, buttonpad_rdesc_ptr,
+	       buttonpad_rdesc_len);
 
 	/* clean up old rdesc and use the new one */
 	drvdata->rsize = rdesc_len;
@@ -1289,7 +1291,10 @@ static int uclogic_probe(struct hid_device *hdev,
 			}
 			drvdata->invert_pen_inrange = true;
 
-			rc = uclogic_probe_buttons(hdev);
+			rc = uclogic_probe_buttons(
+					hdev,
+					uclogic_buttonpad_rdesc,
+					sizeof(uclogic_buttonpad_rdesc));
 			drvdata->has_virtual_pad_interface = !rc;
 		} else {
 			drvdata->ignore_pen_usage = true;
@@ -1347,7 +1352,10 @@ static int uclogic_probe(struct hid_device *hdev,
 				}
 				drvdata->invert_pen_inrange = true;
 
-				rc = uclogic_probe_buttons(hdev);
+				rc = uclogic_probe_buttons(
+						hdev,
+						uclogic_buttonpad_rdesc,
+						sizeof(uclogic_buttonpad_rdesc));
 				drvdata->has_virtual_pad_interface = !rc;
 			} else {
 				drvdata->ignore_pen_usage = true;


### PR DESCRIPTION
This branch includes a cleaned-up version of #85 (hopefully I haven't broken anything!) plus changes that I *think* should be needed to get buttons working on the Huion New 1060 plus. But it still doesn't work correctly; somehow I have the feeling that the button report descriptor introduced here is not being used correctly, or perhaps there's another layer that I know nothing about that is also doing translation.

The output of `usbhid-dump -m 256c:006e -es` when pressing the tablet buttons seems pretty clear and sensible:

    08 E0 01 01 zz 0y 00 00 00 00 00 00

The 12 hardware buttons are encoded in the bits of the twelve-bit hexadecimal number `yzz` from LSB to MSB. But whatever I do, I can't get these to map to buttons 01 through 12. When they work, I get (according to `xinput test <n>`):

| row | side | yzz | button events registered |
| ----- | ----- | ----- | ----- |
| top | left | 0x001 | button 1 |
| top | right | 0x002 | button 2 |
| 2nd | left | 0x004 | button 3 |
| 2nd | right | 0x008 | button 8 |
| 3rd | left | 0x010 | button 9 |
| 3rd | right | 0x020 | button 10 |
| 4th | left | 0x040 | button 11 |
| 4th | right | 0x080 | button 12 |
| 5th | left | 0x100 | button 13 |
| 5th | right | 0x200 | button 14 |
| bottom | left | 0x400 | NONE |
| bottom | right | 0x800 | NONE |

Still mystified.
