### PR TITLE
Joint work by me and Björn Paetzel <kolrabi@kolrabi.de> to support the new hi-resolution Huion tablets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 obj-m := hid-kye.o hid-uclogic.o hid-polostar.o hid-viewsonic.o
-hid-uclogic-objs := hid-uclogic-core.o hid-uclogic-rdesc.o
+hid-uclogic-objs := hid-uclogic-core.o hid-uclogic-rdesc.o hid-uclogic-proxemu.o
 KVERSION := $(shell uname -r)
 KDIR := /lib/modules/$(KVERSION)/build
 PWD := $(shell pwd)

--- a/hid-uclogic-proxemu.c
+++ b/hid-uclogic-proxemu.c
@@ -1,0 +1,138 @@
+/*
+ *  HID driver for UC-Logic devices not fully compliant with HID standard
+ *  - pen proximity-out event emulation
+ *
+ *  Copyright (c) 2018 Andrey Zabolotnyi
+ */
+
+/*
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ */
+
+#include <linux/device.h>
+#include <linux/hid.h>
+#include <linux/workqueue.h>
+#include <linux/delay.h>
+
+#include "hid-uclogic-proxemu.h"
+
+static void uclogic_proxemu_worker(struct work_struct *work)
+{
+	struct proxemu_data *proxemu = container_of(work,
+		struct proxemu_data, work.work);
+	struct hid_device *hdev = proxemu->hdev;
+	int sleep = 0;
+
+	/* if hdev is null, we're finished */
+	if (!hdev) {
+		/* acknowledge that we quit */
+		proxemu->enabled = false;
+		return;
+	}
+
+	if (proxemu->timeout) {
+		sleep = proxemu->timeout - jiffies;
+
+		/* If we finally overtook the timeout,
+		 * generate a prox-out event */
+		if (sleep <= 0) {
+			if (proxemu->last_motion_rep_size >= 2) {
+				u8 *data = proxemu->last_motion_rep;
+
+				/* If last pressure was not reported as zero,
+				 * report zero pressure now, otherwise many programs
+				 * that do not handle proximity reports (e.g. terminals)
+				 * will not release the active mouse grab.
+				 * Same applies to tip switch bit, reset it so that
+				 * a button release event is generated.
+				 */
+				if ((data [1] & 1) || data [6] || data [7]) {
+					/* tip switch is released */
+					data [1] &= ~1;
+					/* force pen pressure to zero */
+					data [6] = data [7] = 0;
+					hid_input_report(hdev, HID_INPUT_REPORT,
+						data, proxemu->last_motion_rep_size, 0);
+				}
+
+				proxemu->state = false;
+
+				/* uclogic_raw_event will clear the proximity
+				 * bit in report due to proximity == false */
+				hid_input_report(hdev, HID_INPUT_REPORT,
+					data, proxemu->last_motion_rep_size, 0);
+			}
+
+			/* don't send more prox-outs, first motion event will be prox-in */
+			proxemu->timeout = 0;
+		}
+	}
+
+	if (sleep <= 0)
+		/* Next prox-out event will be generated not earlier
+		   than EMULATE_PROXOUT_TIME milliseconds */
+		sleep = msecs_to_jiffies(EMULATE_PROXOUT_TIME);
+
+	/* Re-schedule ourselves */
+	schedule_delayed_work(&proxemu->work, sleep);
+}
+
+void uclogic_proxemu_raw_event(struct proxemu_data *proxemu, u8 *data, int size)
+{
+	if (!proxemu->enabled)
+		return;
+
+	/* Ignore all reports except UCLOGIC_HIRES_PEN_REPORT_ID */
+	if (data [0] != 8)
+		return;
+
+	/* Remember the last valid pen report */
+	if (size <= sizeof(proxemu->last_motion_rep)) {
+		proxemu->last_motion_rep_size = size;
+		memcpy(proxemu->last_motion_rep, data, size);
+	}
+
+	/* If this is the first report after inactivity,
+	 * it is a proximity-in event */
+	if (!proxemu->state && (proxemu->timeout == 0))
+		proxemu->state = true;
+
+	if (proxemu->state)
+		data [1] |= 0x80;
+	else
+		data [1] &= ~0x80;
+
+	/* We can't even rely on pressure being 0 to start waiting for inactivity,
+	 * because if you pull quickly the pen from the tablet, a event with zero
+	 * pressure won't even be generated. So we count inactivity starting from
+	 * last received any motion event.
+	 */
+	proxemu->timeout = jiffies + msecs_to_jiffies(EMULATE_PROXOUT_TIME);
+}
+
+void uclogic_proxemu_init(struct proxemu_data *proxemu, struct hid_device *hdev)
+{
+	/* proxemu_data is supposed to be zeroed by e.g. kzalloc() */
+
+	proxemu->enabled = true;
+	proxemu->hdev = hdev;
+
+	INIT_DELAYED_WORK(&proxemu->work, uclogic_proxemu_worker);
+	schedule_delayed_work(&proxemu->work,
+		msecs_to_jiffies(EMULATE_PROXOUT_TIME));
+}
+
+void uclogic_proxemu_stop(struct proxemu_data *proxemu)
+{
+	if (!proxemu->enabled)
+		return;
+
+	/* tell the worker to finish */
+	proxemu->hdev = NULL;
+	/* we could do some math here, but meh... */
+	while (proxemu->enabled)
+		msleep(EMULATE_PROXOUT_TIME / 2);
+}

--- a/hid-uclogic-proxemu.h
+++ b/hid-uclogic-proxemu.h
@@ -1,0 +1,47 @@
+/*
+ *  HID driver for UC-Logic devices not fully compliant with HID standard
+ *  - pen proximity-out event emulation
+ *
+ *  Copyright (c) 2018 Andrey Zabolotnyi
+ */
+
+/*
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ */
+
+#ifndef _HID_UCLOGIC_PROXEMU_H
+#define _HID_UCLOGIC_PROXEMU_H
+
+/* Generate a synthetic proximity-out after 250ms of tablet inactivity.
+ * This can be made even smaller, as the pen in tablet proximity continuously
+ * generates events, even if pen is not moved.
+ */
+#define EMULATE_PROXOUT_TIME	250
+
+struct proxemu_data {
+	/* if set, proximity-out events will be emulated by generating an
+	 * synthetic event after some period of inactivity.
+	 */
+	volatile bool enabled;
+	/* the emulated pen proximity state */
+	bool state;
+	/* the next system jiffie when proximity timeout will happen */
+	unsigned long timeout;
+	/* the background task that generates delayed proximity-out */
+	struct delayed_work work;
+	/* the HID device we're bound to */
+	struct hid_device *hdev;
+	/* place for the last motion report, so that we can build
+	 * a proximity-out event from it */
+	u8 last_motion_rep [16];
+	unsigned last_motion_rep_size;
+};
+
+extern void uclogic_proxemu_init(struct proxemu_data *proxemu, struct hid_device *hdev);
+extern void uclogic_proxemu_stop(struct proxemu_data *proxemu);
+extern void uclogic_proxemu_raw_event(struct proxemu_data *proxemu, u8 *data, int size);
+
+#endif /* _HID_UCLOGIC_PROXEMU_H */

--- a/hid-uclogic-rdesc.c
+++ b/hid-uclogic-rdesc.c
@@ -773,3 +773,31 @@ const __u8 uclogic_rdesc_tablet_hires_template_arr[] = {
 
 const size_t uclogic_rdesc_tablet_hires_template_size =
 			sizeof(uclogic_rdesc_tablet_hires_template_arr);
+
+/* Fixed virtual pad report descriptor for hi-res tablets */
+const __u8 uclogic_rdesc_buttonpad_hires_arr[] = {
+	0x05, 0x01,             /*  Usage Page (Desktop),               */
+	0x09, 0x07,             /*  Usage (Keypad),                     */
+	0xA1, 0x01,             /*  Collection (Application),           */
+	0x85, 0xF7,             /*      Report ID (247),                */
+	0x05, 0x0D,             /*      Usage Page (Digitizer),         */
+	0x09, 0x39,             /*      Usage (Tablet Function Keys),   */
+	0xA0,                   /*      Collection (Physical),          */
+	0x05, 0x09,             /*          Usage Page (Button),        */
+	0x14,                   /*          Logical Minimum (0),        */
+	0x25, 0x01,             /*          Logical Maximum (1),        */
+	0x75, 0x01,             /*          Report Size (1),            */
+	0x95, 0x18,             /*          Report Count (24),          */
+	0x81, 0x01,             /*          Input (Constant),           */
+	0x19, 0x01,             /*          Usage Minimum (01h),        */
+	0x29, 0x0C,             /*          Usage Maximum (0Ch),        */
+	0x95, 0x0C,             /*          Report Count (12),          */
+	0x81, 0x02,             /*          Input (Variable),           */
+	0x95, 0x34,             /*          Report Count (52),          */
+	0x81, 0x01,             /*          Input (Constant),           */
+	0xC0,                   /*      End Collection,                 */
+	0xC0                    /*  End Collection                      */
+};
+
+const size_t uclogic_rdesc_buttonpad_hires_size =
+			sizeof(uclogic_rdesc_buttonpad_hires_arr);

--- a/hid-uclogic-rdesc.c
+++ b/hid-uclogic-rdesc.c
@@ -717,3 +717,59 @@ const __u8 uclogic_rdesc_buttonpad_arr[] = {
 const size_t uclogic_rdesc_buttonpad_size =
 			sizeof(uclogic_rdesc_buttonpad_arr);
 
+/* Fixed report descriptor template */
+const __u8 uclogic_rdesc_tablet_hires_template_arr[] = {
+	0x05, 0x0D,             /*  Usage Page (Digitizer),                 */
+	0x09, 0x02,             /*  Usage (Pen),                            */
+	0xA1, 0x01,             /*  Collection (Application),               */
+	0x85, 0x08,             /*      Report ID (8),                      */
+	0x09, 0x20,             /*      Usage (Stylus),                     */
+	0xA0,                   /*      Collection (Physical),              */
+	0x14,                   /*          Logical Minimum (0),            */
+	0x25, 0x01,             /*          Logical Maximum (1),            */
+	0x75, 0x01,             /*          Report Size (1),                */
+	0x09, 0x42,             /*          Usage (Tip Switch),             */
+	0x09, 0x44,             /*          Usage (Barrel Switch),          */
+	0x09, 0x46,             /*          Usage (Tablet Pick),            */
+	0x95, 0x03,             /*          Report Count (3),               */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0x95, 0x03,             /*          Report Count (3),               */
+	0x81, 0x03,             /*          Input (Constant, Variable),     */
+	0x09, 0x32,             /*          Usage (In Range),               */
+	0x95, 0x01,             /*          Report Count (1),               */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0x95, 0x01,             /*          Report Count (1),               */
+	0x81, 0x03,             /*          Input (Constant, Variable),     */
+	0x75, 0x10,             /*          Report Size (16),               */
+	0x95, 0x01,             /*          Report Count (1),               */
+	0xA4,                   /*          Push,                           */
+	0x05, 0x01,             /*          Usage Page (Desktop),           */
+	0x65, 0x13,             /*          Unit (Inch),                    */
+	0x55, 0xFD,             /*          Unit Exponent (-3),             */
+	0x34,                   /*          Physical Minimum (0),           */
+	0x09, 0x30,             /*          Usage (X),                      */
+	0x27,
+	UCLOGIC_RDESC_PH(X_LM), /*          Logical Maximum (PLACEHOLDER),  */
+	0x47,
+	UCLOGIC_RDESC_PH(X_PM), /*          Physical Maximum (PLACEHOLDER), */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0x09, 0x31,             /*          Usage (Y),                      */
+	0x27,
+	UCLOGIC_RDESC_PH(Y_LM), /*          Logical Maximum (PLACEHOLDER),  */
+	0x47,
+	UCLOGIC_RDESC_PH(Y_PM), /*          Physical Maximum (PLACEHOLDER), */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0xB4,                   /*          Pop,                            */
+	0x09, 0x30,             /*          Usage (Tip Pressure),           */
+	0x27,
+	UCLOGIC_RDESC_PH(PRESSURE_LM),
+				/*          Logical Maximum (PLACEHOLDER),  */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0x95, 0x02,             /*          Report Count (2),               */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0xC0,                   /*      End Collection,                     */
+	0xC0                    /*  End Collection                          */
+};
+
+const size_t uclogic_rdesc_tablet_hires_template_size =
+			sizeof(uclogic_rdesc_tablet_hires_template_arr);

--- a/hid-uclogic-rdesc.c
+++ b/hid-uclogic-rdesc.c
@@ -733,13 +733,11 @@ const __u8 uclogic_rdesc_tablet_hires_template_arr[] = {
 	0x09, 0x46,             /*          Usage (Tablet Pick),            */
 	0x95, 0x03,             /*          Report Count (3),               */
 	0x81, 0x02,             /*          Input (Variable),               */
-	0x95, 0x03,             /*          Report Count (3),               */
-	0x81, 0x03,             /*          Input (Constant, Variable),     */
+	0x95, 0x04,             /*          Report Count (4),               */
+	0x81, 0x01,             /*          Input (Constant),               */
 	0x09, 0x32,             /*          Usage (In Range),               */
 	0x95, 0x01,             /*          Report Count (1),               */
 	0x81, 0x02,             /*          Input (Variable),               */
-	0x95, 0x01,             /*          Report Count (1),               */
-	0x81, 0x03,             /*          Input (Constant, Variable),     */
 	0x75, 0x10,             /*          Report Size (16),               */
 	0x95, 0x01,             /*          Report Count (1),               */
 	0xA4,                   /*          Push,                           */
@@ -766,7 +764,7 @@ const __u8 uclogic_rdesc_tablet_hires_template_arr[] = {
 				/*          Logical Maximum (PLACEHOLDER),  */
 	0x81, 0x02,             /*          Input (Variable),               */
 	0x95, 0x02,             /*          Report Count (2),               */
-	0x81, 0x02,             /*          Input (Variable),               */
+	0x81, 0x01,             /*          Input (Constant),               */
 	0xC0,                   /*      End Collection,                     */
 	0xC0                    /*  End Collection                          */
 };

--- a/hid-uclogic-rdesc.h
+++ b/hid-uclogic-rdesc.h
@@ -111,4 +111,8 @@ extern const size_t uclogic_rdesc_buttonpad_size;
 extern const __u8 uclogic_rdesc_tablet_hires_template_arr[];
 extern const size_t uclogic_rdesc_tablet_hires_template_size;
 
+/* Report descriptor for the newer high resolution tablet pad */
+extern const __u8 uclogic_rdesc_buttonpad_hires_arr[];
+extern const size_t uclogic_rdesc_buttonpad_hires_size;
+
 #endif /* _HID_UCLOGIC_RDESC_H */

--- a/hid-uclogic-rdesc.h
+++ b/hid-uclogic-rdesc.h
@@ -107,4 +107,8 @@ extern const size_t uclogic_rdesc_ugee_ex07_template_size;
 extern const __u8 uclogic_rdesc_buttonpad_arr[];
 extern const size_t uclogic_rdesc_buttonpad_size;
 
+/* Report descriptor for the newer high resolution tablets */
+extern const __u8 uclogic_rdesc_tablet_hires_template_arr[];
+extern const size_t uclogic_rdesc_tablet_hires_template_size;
+
 #endif /* _HID_UCLOGIC_RDESC_H */


### PR DESCRIPTION
This is a reworked pull request #113.

All incremental changes have been isolated in separate commits. All intermediate repository states are compilable and tested to work.

Also I managed to catch & fix yet another firmware bug - when you move the pen quickly off the tablet, not only pressure is not reported as 0 (leaving tablet-aware applications thinking that pen is still applied with some non-zero pressure), but even the tip switch is not reported as zero, which prevents X11 from generating a button release event, thus even non-tablet-aware apps will be misleaded.

Exercise: with the old driver, open a terminal and mark some text with the pen. Keep it pressed tight, then very quickly move it away from the tablet. The pressure=0 and tip switch=0 are not reported, thus terminal is left with an active mouse grab. Now try to move the regular mouse around (without pressing any buttons), the selection will follow the cursor. Also, you can't exit this mouse grab unless you again put the stylus on the tablet and gently move it away..

The correct event sequence now look this way in evtest:

```
Event: time 1516747806.799359, type 3 (EV_ABS), code 0 (ABS_X), value 1746
Event: time 1516747806.799359, type 3 (EV_ABS), code 1 (ABS_Y), value 12868
Event: time 1516747806.799359, type 3 (EV_ABS), code 24 (ABS_PRESSURE), value 3764
Event: time 1516747806.799359, -------------- SYN_REPORT ------------
Event: time 1516747806.803357, type 3 (EV_ABS), code 0 (ABS_X), value 1711
Event: time 1516747806.803357, type 3 (EV_ABS), code 1 (ABS_Y), value 12768
Event: time 1516747806.803357, type 3 (EV_ABS), code 24 (ABS_PRESSURE), value 3080
Event: time 1516747806.803357, -------------- SYN_REPORT ------------

// the above is the last event actually reported by hardware when I quickly moved the pen away

Event: time 1516747807.053439, type 4 (EV_MSC), code 4 (MSC_SCAN), value d0042
Event: time 1516747807.053439, type 1 (EV_KEY), code 330 (BTN_TOUCH), value 0
Event: time 1516747807.053439, type 3 (EV_ABS), code 24 (ABS_PRESSURE), value 0
Event: time 1516747807.053439, -------------- SYN_REPORT ------------

// This is the first synthetic event generated by proximity-out emulation code.
// This will not be generated if the tablet behaves well (e.g. reports TOUCH=0 and PRESSURE=0 itself)

Event: time 1516747807.053451, type 1 (EV_KEY), code 320 (BTN_TOOL_PEN), value 0
Event: time 1516747807.053451, -------------- SYN_REPORT ------------

// and this is the second synthetic event generated by proximity-out emulation code
```