### PR TITLE
Fix building Debian package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .*
 /Module.symvers
 /modules.order
+debian/debhelper-build-stamp

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ drivers as a Debian package, make sure you have `dpkg-dev`, `debhelper`, and
 `dkms` packages installed, and run the following command in the source
 directory:
 
-    dpkg-buildpackage -b --no-sign
+    dpkg-buildpackage -b -uc
 
 The resulting package files will be written to the parent directory.
 


### PR DESCRIPTION
Hi Nick, 
Pull Request for fixing building Debian package. Because it always creates the `debhelper-build-stamp` file  after the command `dpkg-buildpackage -b -uc`. I put it into gitignore.