### PR TITLE
WIP: Refactor UC-Logic driver and support new Huion tablets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 obj-m := hid-kye.o hid-uclogic.o hid-polostar.o hid-viewsonic.o
-hid-uclogic-objs := hid-uclogic-core.o hid-uclogic-rdesc.o
+hid-uclogic-objs := \
+	hid-uclogic-core.o \
+	hid-uclogic-rdesc.o \
+	hid-uclogic-params.o
 KVERSION := $(shell uname -r)
 KDIR := /lib/modules/$(KVERSION)/build
 PWD := $(shell pwd)

--- a/compat.h
+++ b/compat.h
@@ -26,4 +26,21 @@
 		      hid_unregister_driver)
 #endif
 
+#ifndef from_timer
+#define from_timer(var, callback_timer, timer_fieldname) \
+	container_of(callback_timer, typeof(*var), timer_fieldname)
+#endif
+
+/* If we're on an old kernel where setup_timer was still defined */
+#ifdef setup_timer
+/*
+ * Define a replacement of timer_setup found in newer kernels.
+ * NOTE Casting function pointers like this is a dirty hack,
+ * 	but will probably work, and should do for now.
+ */
+#define timer_setup(timer, callback, flags) \
+	__setup_timer((timer), (void (*)(unsigned long))(callback), \
+			(unsigned long)(timer), (flags))
+#endif
+
 #endif

--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -26,8 +26,6 @@
 #include "compat.h"
 #include <linux/version.h>
 
-#define UCLOGIC_PEN_REPORT_ID	0x07
-
 /* Driver data */
 struct uclogic_drvdata {
 	/* Interface parameters */

--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -142,6 +142,12 @@ static int uclogic_probe(struct hid_device *hdev,
 		hid_err(hdev, "failed probing device parameters\n");
 		goto failure;
 	}
+	if (drvdata->params == NULL) {
+		hid_warn(hdev, "interface parameters not found");
+	} else {
+		uclogic_params_dump(drvdata->params, hdev,
+					"interface parameters:\n");
+	}
 
 	rc = hid_parse(hdev);
 	if (rc) {

--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -18,7 +18,7 @@
 #include <linux/usb.h>
 #include <asm/unaligned.h>
 #include "usbhid/usbhid.h"
-#include "hid-uclogic-rdesc.h"
+#include "hid-uclogic-params.h"
 
 #include "hid-ids.h"
 
@@ -27,110 +27,20 @@
 
 #define UCLOGIC_PEN_REPORT_ID	0x07
 
-/* Parameter indices */
-enum uclogic_prm {
-	UCLOGIC_PRM_X_LM	= 1,
-	UCLOGIC_PRM_Y_LM	= 2,
-	UCLOGIC_PRM_PRESSURE_LM	= 4,
-	UCLOGIC_PRM_RESOLUTION	= 5,
-	UCLOGIC_PRM_NUM
-};
-
 /* Driver data */
 struct uclogic_drvdata {
-	__u8 *rdesc;
-	unsigned int rsize;
-	bool pen_enabled;
-	bool buttons_enabled;
-	bool invert_pen_inrange;
-	bool ignore_pen_usage;
-	bool has_virtual_pad_interface;
+	struct uclogic_params *params;
 };
 
 static __u8 *uclogic_report_fixup(struct hid_device *hdev, __u8 *rdesc,
 					unsigned int *rsize)
 {
-	struct usb_interface *iface = to_usb_interface(hdev->dev.parent);
-	__u8 iface_num = iface->cur_altsetting->desc.bInterfaceNumber;
 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
-
-	if (drvdata->rdesc != NULL) {
-		rdesc = drvdata->rdesc;
-		*rsize = drvdata->rsize;
-		return rdesc;
+	struct uclogic_params *params = drvdata->params;
+	if (params != NULL && params->rdesc_ptr != NULL) {
+		rdesc = params->rdesc_ptr;
+		*rsize = params->rdesc_size;
 	}
-
-	switch (hdev->product) {
-	case USB_DEVICE_ID_UCLOGIC_TABLET_PF1209:
-		if (*rsize == UCLOGIC_RDESC_PF1209_ORIG_SIZE) {
-			rdesc = uclogic_rdesc_pf1209_fixed_arr;
-			*rsize = uclogic_rdesc_pf1209_fixed_size;
-		}
-		break;
-	case USB_DEVICE_ID_UCLOGIC_TABLET_WP4030U:
-		if (*rsize == UCLOGIC_RDESC_WPXXXXU_ORIG_SIZE) {
-			rdesc = uclogic_rdesc_wp4030u_fixed_arr;
-			*rsize = uclogic_rdesc_wp4030u_fixed_size;
-		}
-		break;
-	case USB_DEVICE_ID_UCLOGIC_TABLET_WP5540U:
-		if (*rsize == UCLOGIC_RDESC_WPXXXXU_ORIG_SIZE) {
-			rdesc = uclogic_rdesc_wp5540u_fixed_arr;
-			*rsize = uclogic_rdesc_wp5540u_fixed_size;
-		}
-		break;
-	case USB_DEVICE_ID_UCLOGIC_TABLET_WP8060U:
-		if (*rsize == UCLOGIC_RDESC_WPXXXXU_ORIG_SIZE) {
-			rdesc = uclogic_rdesc_wp8060u_fixed_arr;
-			*rsize = uclogic_rdesc_wp8060u_fixed_size;
-		}
-		break;
-	case USB_DEVICE_ID_UCLOGIC_TABLET_WP1062:
-		if (*rsize == UCLOGIC_RDESC_WP1062_ORIG_SIZE) {
-			rdesc = uclogic_rdesc_wp1062_fixed_arr;
-			*rsize = uclogic_rdesc_wp1062_fixed_size;
-		}
-		break;
-	case USB_DEVICE_ID_UCLOGIC_WIRELESS_TABLET_TWHL850:
-		switch (iface_num) {
-		case 0:
-			if (*rsize == UCLOGIC_RDESC_TWHL850_ORIG0_SIZE) {
-				rdesc = uclogic_rdesc_twhl850_fixed0_arr;
-				*rsize = uclogic_rdesc_twhl850_fixed0_size;
-			}
-			break;
-		case 1:
-			if (*rsize == UCLOGIC_RDESC_TWHL850_ORIG1_SIZE) {
-				rdesc = uclogic_rdesc_twhl850_fixed1_arr;
-				*rsize = uclogic_rdesc_twhl850_fixed1_size;
-			}
-			break;
-		case 2:
-			if (*rsize == UCLOGIC_RDESC_TWHL850_ORIG2_SIZE) {
-				rdesc = uclogic_rdesc_twhl850_fixed2_arr;
-				*rsize = uclogic_rdesc_twhl850_fixed2_size;
-			}
-			break;
-		}
-		break;
-	case USB_DEVICE_ID_UCLOGIC_TABLET_TWHA60:
-		switch (iface_num) {
-		case 0:
-			if (*rsize == UCLOGIC_RDESC_TWHA60_ORIG0_SIZE) {
-				rdesc = uclogic_rdesc_twha60_fixed0_arr;
-				*rsize = uclogic_rdesc_twha60_fixed0_size;
-			}
-			break;
-		case 1:
-			if (*rsize == UCLOGIC_RDESC_TWHA60_ORIG1_SIZE) {
-				rdesc = uclogic_rdesc_twha60_fixed1_arr;
-				*rsize = uclogic_rdesc_twha60_fixed1_size;
-			}
-			break;
-		}
-		break;
-	}
-
 	return rdesc;
 }
 
@@ -139,9 +49,10 @@ static int uclogic_input_mapping(struct hid_device *hdev, struct hid_input *hi,
 		unsigned long **bit, int *max)
 {
 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
+	struct uclogic_params *params = drvdata->params;
 
 	/* discard the unused pen interface */
-	if ((drvdata->ignore_pen_usage) &&
+	if (params != NULL && params->pen_unused &&
 	    (field->application == HID_DG_PEN))
 		return -1;
 
@@ -204,230 +115,11 @@ static int uclogic_input_configured(struct hid_device *hdev,
 #undef RETURN_SUCCESS
 
 
-/**
- * Enable fully-functional pen input mode and retrieve its parameters.
- *
- * @hdev:	HID device
- * @pbuf:	Location for the kmalloc'ed parameter array with
- * 		UCLOGIC_PRM_NUM elements.
- */
-static int uclogic_enable_pen(struct hid_device *hdev, __le16 **pbuf)
-{
-	int rc;
-	struct usb_device *usb_dev = hid_to_usb_dev(hdev);
-	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
-	__le16 *buf = NULL;
-	size_t len;
-
-	/*
-	 * Read string descriptor containing pen input parameters. The
-	 * specific string descriptor and data were discovered by sniffing the
-	 * Windows driver traffic.
-	 * NOTE: This enables fully-functional pen input mode.
-	 */
-	len = UCLOGIC_PRM_NUM * sizeof(*buf);
-	buf = kmalloc(len, GFP_KERNEL);
-	if (buf == NULL) {
-		rc = -ENOMEM;
-		goto cleanup;
-	}
-	rc = usb_control_msg(usb_dev, usb_rcvctrlpipe(usb_dev, 0),
-				USB_REQ_GET_DESCRIPTOR, USB_DIR_IN,
-				(USB_DT_STRING << 8) + 0x64,
-				0x0409, buf, len,
-				USB_CTRL_GET_TIMEOUT);
-	if (rc == -EPIPE) {
-		hid_err(hdev, "pen input parameters not found\n");
-		rc = -ENODEV;
-		goto cleanup;
-	} else if (rc < 0) {
-		hid_err(hdev, "failed to get pen input parameters: %d\n", rc);
-		rc = -ENODEV;
-		goto cleanup;
-	} else if (rc != len) {
-		hid_err(hdev, "invalid pen input parameters\n");
-		rc = -ENODEV;
-		goto cleanup;
-	}
-
-	drvdata->pen_enabled = true;
-	*pbuf = buf;
-	buf = NULL;
-	rc = 0;
-
-cleanup:
-	kfree(buf);
-	return rc;
-}
-
-/**
- * Enable fully-functional pen input mode, retrieve pen input parameters and
- * generate corresponding report descriptor.
- *
- * @hdev:		HID device
- * @rdesc_template_ptr	Report descriptor template pointer
- * @rdesc_template_len	Report descriptor template length
- */
-static int uclogic_probe_pen(struct hid_device *hdev,
-				const __u8 *rdesc_template_ptr,
-				size_t rdesc_template_len)
-{
-	int rc;
-	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
-	__le16 *buf = NULL;
-	s32 params[UCLOGIC_RDESC_PEN_PH_ID_NUM];
-	s32 resolution;
-	__u8 *p;
-	s32 v;
-
-	/* Enable pen input and get raw parameters */
-	rc = uclogic_enable_pen(hdev, &buf);
-	if (rc != 0) {
-		goto cleanup;
-	}
-
-	/* Extract pen input parameters */
-	params[UCLOGIC_RDESC_PEN_PH_ID_X_LM] =
-		le16_to_cpu(buf[UCLOGIC_PRM_X_LM]);
-	params[UCLOGIC_RDESC_PEN_PH_ID_Y_LM] =
-		le16_to_cpu(buf[UCLOGIC_PRM_Y_LM]);
-	params[UCLOGIC_RDESC_PEN_PH_ID_PRESSURE_LM] =
-		le16_to_cpu(buf[UCLOGIC_PRM_PRESSURE_LM]);
-	resolution = le16_to_cpu(buf[UCLOGIC_PRM_RESOLUTION]);
-	if (resolution == 0) {
-		params[UCLOGIC_RDESC_PEN_PH_ID_X_PM] = 0;
-		params[UCLOGIC_RDESC_PEN_PH_ID_Y_PM] = 0;
-	} else {
-		params[UCLOGIC_RDESC_PEN_PH_ID_X_PM] =
-			params[UCLOGIC_RDESC_PEN_PH_ID_X_LM] * 1000 /
-			resolution;
-		params[UCLOGIC_RDESC_PEN_PH_ID_Y_PM] =
-			params[UCLOGIC_RDESC_PEN_PH_ID_Y_LM] * 1000 /
-			resolution;
-	}
-
-	/* Allocate fixed report descriptor */
-	drvdata->rdesc = devm_kzalloc(&hdev->dev,
-				rdesc_template_len,
-				GFP_KERNEL);
-	if (drvdata->rdesc == NULL) {
-		rc = -ENOMEM;
-		goto cleanup;
-	}
-	drvdata->rsize = rdesc_template_len;
-
-	/* Format fixed report descriptor */
-	memcpy(drvdata->rdesc, rdesc_template_ptr, drvdata->rsize);
-	for (p = drvdata->rdesc;
-	     p <= drvdata->rdesc + drvdata->rsize - 4;) {
-		if (p[0] == 0xFE && p[1] == 0xED && p[2] == 0x1D &&
-		    p[3] < ARRAY_SIZE(params)) {
-			v = params[p[3]];
-			put_unaligned(cpu_to_le32(v), (s32 *)p);
-			p += 4;
-		} else {
-			p++;
-		}
-	}
-
-	rc = 0;
-
-cleanup:
-	kfree(buf);
-	return rc;
-}
-
-/**
- * Enable generic button mode.
- *
- * @hdev:	HID device
- */
-static int uclogic_enable_buttons(struct hid_device *hdev)
-{
-	int rc;
-	struct usb_device *usb_dev = hid_to_usb_dev(hdev);
-	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
-	char *str_buf;
-	size_t str_len = 16;
-
-	str_buf = kzalloc(str_len, GFP_KERNEL);
-	if (str_buf == NULL) {
-		rc = -ENOMEM;
-		goto cleanup;
-	}
-
-	rc = usb_string(usb_dev, 0x7b, str_buf, str_len);
-	if (rc == -EPIPE) {
-		hid_info(hdev, "button mode setting not found\n");
-		rc = 0;
-		goto cleanup;
-	} else if (rc < 0) {
-		hid_err(hdev, "failed to enable abstract keyboard\n");
-		goto cleanup;
-	} else if (strncmp(str_buf, "HK On", rc)) {
-		hid_info(hdev, "invalid answer when requesting buttons: '%s'\n",
-			str_buf);
-		rc = -EINVAL;
-		goto cleanup;
-	}
-
-	drvdata->buttons_enabled = true;
-	rc = 0;
-cleanup:
-	kfree(str_buf);
-	return rc;
-}
-
-/**
- * Enable generic button mode, and substitute corresponding report descriptor.
- *
- * @hdev:	HID device
- */
-static int uclogic_probe_buttons(struct hid_device *hdev)
-{
-	int rc;
-	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
-	unsigned char *rdesc;
-	size_t rdesc_len;
-
-	/* Enable generic button mode */
-	rc = uclogic_enable_buttons(hdev);
-	if (rc != 0) {
-		goto cleanup;
-	}
-
-	/* Re-allocate fixed report descriptor */
-	rdesc_len = drvdata->rsize + uclogic_rdesc_buttonpad_size;
-	rdesc = devm_kzalloc(&hdev->dev, rdesc_len, GFP_KERNEL);
-	if (!rdesc) {
-		rc = -ENOMEM;
-		goto cleanup;
-	}
-
-	memcpy(rdesc, drvdata->rdesc, drvdata->rsize);
-
-	/* Append the buttonpad descriptor */
-	memcpy(rdesc + drvdata->rsize, uclogic_rdesc_buttonpad_arr,
-	       uclogic_rdesc_buttonpad_size);
-
-	/* clean up old rdesc and use the new one */
-	drvdata->rsize = rdesc_len;
-	devm_kfree(&hdev->dev, drvdata->rdesc);
-	drvdata->rdesc = rdesc;
-
-	rc = 0;
-
-cleanup:
-	return rc;
-}
-
 static int uclogic_probe(struct hid_device *hdev,
 		const struct hid_device_id *id)
 {
 	int rc;
-	struct usb_interface *intf = to_usb_interface(hdev->dev.parent);
-	struct usb_device *udev = hid_to_usb_dev(hdev);
-	struct uclogic_drvdata *drvdata;
+	struct uclogic_drvdata *drvdata = NULL;
 
 	/*
 	 * libinput requires the pad interface to be on a different node
@@ -438,152 +130,54 @@ static int uclogic_probe(struct hid_device *hdev,
 
 	/* Allocate and assign driver data */
 	drvdata = devm_kzalloc(&hdev->dev, sizeof(*drvdata), GFP_KERNEL);
-	if (drvdata == NULL)
-		return -ENOMEM;
+	if (drvdata == NULL) {
+		rc = -ENOMEM;
+		goto cleanup;
+	}
 
 	hid_set_drvdata(hdev, drvdata);
 
-	switch (id->product) {
-	case USB_DEVICE_ID_HUION_TABLET:
-	case USB_DEVICE_ID_YIYNOVA_TABLET:
-	case USB_DEVICE_ID_UCLOGIC_UGEE_TABLET_81:
-	case USB_DEVICE_ID_UCLOGIC_DRAWIMAGE_G3:
-	case USB_DEVICE_ID_UCLOGIC_UGEE_TABLET_45:
-	case USB_DEVICE_ID_UCLOGIC_UGEE_TABLET_47:
-		/* If this is the pen interface */
-		if (intf->cur_altsetting->desc.bInterfaceNumber == 0) {
-			rc = uclogic_probe_pen(
-					hdev,
-					uclogic_rdesc_pen_template_arr,
-					uclogic_rdesc_pen_template_size);
-			if (rc) {
-				hid_err(hdev, "pen enabling failed\n");
-				return rc;
-			}
-			drvdata->invert_pen_inrange = true;
-
-			rc = uclogic_probe_buttons(hdev);
-			drvdata->has_virtual_pad_interface = !rc;
-		} else {
-			drvdata->ignore_pen_usage = true;
-		}
-		break;
-	case USB_DEVICE_ID_UGTIZER_TABLET_GP0610:
-	case USB_DEVICE_ID_UGEE_XPPEN_TABLET_G540:
-		/* If this is the pen interface */
-		if (intf->cur_altsetting->desc.bInterfaceNumber == 1) {
-			rc = uclogic_probe_pen(
-					hdev,
-					uclogic_rdesc_pen_template_arr,
-					uclogic_rdesc_pen_template_size);
-			if (rc) {
-				hid_err(hdev, "pen enabling failed\n");
-				return rc;
-			}
-			drvdata->invert_pen_inrange = true;
-		} else {
-			drvdata->ignore_pen_usage = true;
-		}
-		break;
-	case USB_DEVICE_ID_UGEE_TABLET_EX07S:
-		/* If this is the pen interface */
-		if (intf->cur_altsetting->desc.bInterfaceNumber == 1) {
-			rc = uclogic_probe_pen(
-					hdev,
-					uclogic_rdesc_ugee_ex07_template_arr,
-					uclogic_rdesc_ugee_ex07_template_size);
-			if (rc) {
-				hid_err(hdev, "pen enabling failed\n");
-				return rc;
-			}
-			drvdata->invert_pen_inrange = true;
-		} else {
-			/* Ignore unused interface #0 */
-			return -ENODEV;
-		}
-		break;
-	case USB_DEVICE_ID_UCLOGIC_TABLET_TWHA60:
-		/*
-		 * If it is the three-interface version, which is known to
-		 * respond to initialization.
-		 */
-		if (udev->config->desc.bNumInterfaces == 3) {
-			/* If it is the pen interface */
-			if (intf->cur_altsetting->desc.bInterfaceNumber == 0) {
-				rc = uclogic_probe_pen(
-					hdev,
-					uclogic_rdesc_pen_template_arr,
-					uclogic_rdesc_pen_template_size);
-				if (rc) {
-					hid_err(hdev, "pen enabling failed\n");
-					return rc;
-				}
-				drvdata->invert_pen_inrange = true;
-
-				rc = uclogic_probe_buttons(hdev);
-				drvdata->has_virtual_pad_interface = !rc;
-			} else {
-				drvdata->ignore_pen_usage = true;
-			}
-		}
-		break;
-	case USB_DEVICE_ID_UCLOGIC_TABLET_WP5540U:
-		/* If this is the pen interface of WP5540U v2 */
-		if (hdev->dev_rsize == UCLOGIC_RDESC_WP5540U_V2_ORIG_SIZE &&
-		    intf->cur_altsetting->desc.bInterfaceNumber == 0) {
-			rc = uclogic_probe_pen(
-					hdev,
-					uclogic_rdesc_pen_template_arr,
-					uclogic_rdesc_pen_template_size);
-			if (rc) {
-				hid_err(hdev, "pen enabling failed\n");
-				return rc;
-			}
-			drvdata->invert_pen_inrange = true;
-		}
-		break;
+	/* Initialize the device and retrieve parameters */
+	rc = uclogic_params_probe(&drvdata->params, hdev);
+	if (rc != 0) {
+		hid_err(hdev, "failed probing device parameters\n");
+		goto cleanup;
 	}
 
 	rc = hid_parse(hdev);
 	if (rc) {
 		hid_err(hdev, "parse failed\n");
-		return rc;
+		goto cleanup;
 	}
 
 	rc = hid_hw_start(hdev, HID_CONNECT_DEFAULT);
 	if (rc) {
 		hid_err(hdev, "hw start failed\n");
-		return rc;
+		goto cleanup;
 	}
 
-	return 0;
+	rc = 0;
+
+cleanup:
+	if (drvdata != NULL) {
+		uclogic_params_free(drvdata->params);
+		devm_kfree(&hdev->dev, drvdata);
+	}
+	return rc;
 }
 
 #ifdef CONFIG_PM
 static int uclogic_resume(struct hid_device *hdev)
 {
 	int rc;
-	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
 
-	/* Re-enable pen, if needed */
-	if (drvdata->pen_enabled) {
-		__le16 *buf = NULL;
-		rc = uclogic_enable_pen(hdev, &buf);
-		kfree(buf);
-		if (rc != 0) {
-			return rc;
-		}
+	/* Re-initialize the device, but discard parameters */
+	rc = uclogic_params_probe(NULL, hdev);
+	if (rc != 0) {
+		hid_err(hdev, "failed to re-initialize the device");
 	}
 
-	/* Re-enable buttons, if needed */
-	if (drvdata->buttons_enabled) {
-		rc = uclogic_enable_buttons(hdev);
-		if (rc != 0) {
-			return rc;
-		}
-	}
-
-	return 0;
+	return rc;
 }
 #endif
 
@@ -591,19 +185,60 @@ static int uclogic_raw_event(struct hid_device *hdev, struct hid_report *report,
 			u8 *data, int size)
 {
 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
+	struct uclogic_params *params = drvdata->params;
 
-	if ((report->type == HID_INPUT_REPORT) &&
-	    (report->id == UCLOGIC_PEN_REPORT_ID) &&
+	if (!params->pen_unused &&
+	    (report->type == HID_INPUT_REPORT) &&
+	    (report->id == params->pen_report_id) &&
 	    (size >= 2)) {
-		if (drvdata->has_virtual_pad_interface && (data[1] & 0x20))
-			/* Change to virtual frame button report ID */
-			data[0] = 0xf7;
-		else if (drvdata->invert_pen_inrange)
-			/* Invert the in-range bit */
-			data[1] ^= 0x40;
+		/* If it's the "virtual" frame controls report */
+		if (data[1] & params->pen_report_frame_flag) {
+			/* Change to virtual frame controls report ID */
+			data[0] = params->frame_virtual_report_id;
+		} else {
+			/* If in-range reports are inverted */
+			if (params->pen_report_inrange ==
+				UCLOGIC_PARAMS_PEN_REPORT_INRANGE_INVERTED) {
+				/* Invert the in-range bit */
+				data[1] ^= 0x40;
+			}
+			/*
+			 * If report contains fragmented high-resolution pen
+			 * coordinates
+			 */
+			if (size >= 10 && params->pen_report_fragmented_hires) {
+				u8 pressure_low_byte;
+				u8 pressure_high_byte;
+
+				/* Lift pressure bytes */
+				pressure_low_byte = data[6];
+				pressure_high_byte = data[7];
+				/*
+				 * Move Y coord to make space for high-order X
+				 * coord byte
+				 */
+				data[6] = data[5];
+				data[5] = data[4];
+				/* Move high-order X coord byte */
+				data[4] = data[8];
+				/* Move high-order Y coord byte */
+				data[7] = data[9];
+				/* Place pressure bytes */
+				data[8] = pressure_low_byte;
+				data[9] = pressure_high_byte;
+			}
+		}
 	}
 
 	return 0;
+}
+
+static void uclogic_remove(struct hid_device *hdev)
+{
+	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
+	uclogic_params_free(drvdata->params);
+	drvdata->params = NULL;
+	hid_hw_stop(hdev);
 }
 
 static const struct hid_device_id uclogic_devices[] = {
@@ -639,6 +274,7 @@ static struct hid_driver uclogic_driver = {
 	.name = "uclogic",
 	.id_table = uclogic_devices,
 	.probe = uclogic_probe,
+	.remove = uclogic_remove,
 	.report_fixup = uclogic_report_fixup,
 	.raw_event = uclogic_raw_event,
 	.input_mapping = uclogic_input_mapping,

--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -132,36 +132,35 @@ static int uclogic_probe(struct hid_device *hdev,
 	drvdata = devm_kzalloc(&hdev->dev, sizeof(*drvdata), GFP_KERNEL);
 	if (drvdata == NULL) {
 		rc = -ENOMEM;
-		goto cleanup;
+		goto failure;
 	}
-
 	hid_set_drvdata(hdev, drvdata);
 
 	/* Initialize the device and retrieve parameters */
 	rc = uclogic_params_probe(&drvdata->params, hdev);
 	if (rc != 0) {
 		hid_err(hdev, "failed probing device parameters\n");
-		goto cleanup;
+		goto failure;
 	}
 
 	rc = hid_parse(hdev);
 	if (rc) {
 		hid_err(hdev, "parse failed\n");
-		goto cleanup;
+		goto failure;
 	}
 
 	rc = hid_hw_start(hdev, HID_CONNECT_DEFAULT);
 	if (rc) {
 		hid_err(hdev, "hw start failed\n");
-		goto cleanup;
+		goto failure;
 	}
 
-	rc = 0;
-
-cleanup:
+	return 0;
+failure:
+	/* Assume "remove" might not be called if "probe" failed */
 	if (drvdata != NULL) {
 		uclogic_params_free(drvdata->params);
-		devm_kfree(&hdev->dev, drvdata);
+		drvdata->params = NULL;
 	}
 	return rc;
 }

--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -186,7 +186,8 @@ static int uclogic_raw_event(struct hid_device *hdev, struct hid_report *report,
 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
 	struct uclogic_params *params = drvdata->params;
 
-	if (!params->pen_unused &&
+	if (params != NULL &&
+	    !params->pen_unused &&
 	    (report->type == HID_INPUT_REPORT) &&
 	    (report->id == params->pen_report_id) &&
 	    (size >= 2)) {

--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -139,14 +139,13 @@ static int uclogic_probe(struct hid_device *hdev,
 	/* Initialize the device and retrieve parameters */
 	rc = uclogic_params_probe(&drvdata->params, hdev);
 	if (rc != 0) {
-		hid_err(hdev, "failed probing device parameters\n");
+		hid_err(hdev, "failed probing parameters\n");
 		goto failure;
 	}
 	if (drvdata->params == NULL) {
-		hid_warn(hdev, "interface parameters not found");
+		hid_warn(hdev, "parameters not found");
 	} else {
-		uclogic_params_dump(drvdata->params, hdev,
-					"interface parameters:\n");
+		uclogic_params_dump(drvdata->params, hdev, "parameters:\n");
 	}
 
 	rc = hid_parse(hdev);

--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -236,7 +236,7 @@ static int uclogic_raw_event(struct hid_device *hdev, struct hid_report *report,
 		/* If it's the "virtual" frame controls report */
 		if (data[1] & params->pen_report_frame_flag) {
 			/* Change to virtual frame controls report ID */
-			data[0] = params->frame_report_id;
+			data[0] = params->pen_report_frame_report_id;
 			return 0;
 		}
 		/* If in-range reports are inverted */

--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -32,14 +32,14 @@ struct uclogic_drvdata {
 	struct uclogic_params *params;
 	/* Pen input device */
 	struct input_dev *pen_input;
-	/* Proximity-out timer */
-	struct timer_list proximity_timer;
+	/* In-range timer */
+	struct timer_list inrange_timer;
 };
 
-static void uclogic_proximity_timeout(struct timer_list *t)
+static void uclogic_inrange_timeout(struct timer_list *t)
 {
 	struct uclogic_drvdata *drvdata = from_timer(drvdata, t,
-							proximity_timer);
+							inrange_timer);
 	struct input_dev *input = drvdata->pen_input;
 	input_report_abs(input, ABS_PRESSURE, 0);
 	/* If BTN_TOUCH state is changing */
@@ -165,7 +165,7 @@ static int uclogic_probe(struct hid_device *hdev,
 		rc = -ENOMEM;
 		goto failure;
 	}
-	timer_setup(&drvdata->proximity_timer, uclogic_proximity_timeout, 0);
+	timer_setup(&drvdata->inrange_timer, uclogic_inrange_timeout, 0);
 	hid_set_drvdata(hdev, drvdata);
 
 	/* Initialize the device and retrieve parameters */
@@ -267,12 +267,12 @@ static int uclogic_raw_event(struct hid_device *hdev, struct hid_report *report,
 			data[8] = pressure_low_byte;
 			data[9] = pressure_high_byte;
 		}
-		/* If we need to emulate proximity */
+		/* If we need to emulate in-range detection */
 		if (params->pen_inrange == UCLOGIC_PARAMS_PEN_INRANGE_NONE) {
-			/* Set proximity bit */
+			/* Set in-range bit */
 			data[1] |= 0x40;
-			/* (Re-)start proximity timeout */
-			mod_timer(&drvdata->proximity_timer,
+			/* (Re-)start in-range timeout */
+			mod_timer(&drvdata->inrange_timer,
 					jiffies + msecs_to_jiffies(100));
 		}
 	}
@@ -283,7 +283,7 @@ static int uclogic_raw_event(struct hid_device *hdev, struct hid_report *report,
 static void uclogic_remove(struct hid_device *hdev)
 {
 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
-	del_timer_sync(&drvdata->proximity_timer);
+	del_timer_sync(&drvdata->inrange_timer);
 	hid_hw_stop(hdev);
 	uclogic_params_free(drvdata->params);
 	drvdata->params = NULL;

--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -58,9 +58,9 @@ static __u8 *uclogic_report_fixup(struct hid_device *hdev, __u8 *rdesc,
 {
 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
 	struct uclogic_params *params = drvdata->params;
-	if (params->rdesc_ptr != NULL) {
-		rdesc = params->rdesc_ptr;
-		*rsize = params->rdesc_size;
+	if (params->desc_ptr != NULL) {
+		rdesc = params->desc_ptr;
+		*rsize = params->desc_size;
 	}
 	return rdesc;
 }
@@ -73,8 +73,7 @@ static int uclogic_input_mapping(struct hid_device *hdev, struct hid_input *hi,
 	struct uclogic_params *params = drvdata->params;
 
 	/* discard the unused pen interface */
-	if (params->pen_unused &&
-	    (field->application == HID_DG_PEN))
+	if (params->pen_unused && (field->application == HID_DG_PEN))
 		return -1;
 
 	/* let hid-core decide what to do */
@@ -106,7 +105,7 @@ static int uclogic_input_configured(struct hid_device *hdev,
 	 * If this is the input corresponding to the pen report
 	 * in need of tweaking.
 	 */
-	if (hi->report->id == params->pen_report_id) {
+	if (hi->report->id == params->pen_id) {
 		/* Remember the input device so we can simulate events */
 		drvdata->pen_input = hi->input;
 	}
@@ -229,17 +228,17 @@ static int uclogic_raw_event(struct hid_device *hdev, struct hid_report *report,
 
 	if (!params->pen_unused &&
 	    (report->type == HID_INPUT_REPORT) &&
-	    (report->id == params->pen_report_id) &&
+	    (report->id == params->pen_id) &&
 	    (size >= 2)) {
 		/* If it's the "virtual" frame controls report */
-		if (data[1] & params->pen_report_frame_flag) {
+		if (data[1] & params->pen_frame_flag) {
 			/* Change to virtual frame controls report ID */
-			data[0] = params->pen_report_frame_report_id;
+			data[0] = params->pen_frame_id;
 			return 0;
 		}
 		/* If in-range reports are inverted */
-		if (params->pen_report_inrange ==
-			UCLOGIC_PARAMS_PEN_REPORT_INRANGE_INVERTED) {
+		if (params->pen_inrange ==
+			UCLOGIC_PARAMS_PEN_INRANGE_INVERTED) {
 			/* Invert the in-range bit */
 			data[1] ^= 0x40;
 		}
@@ -247,7 +246,7 @@ static int uclogic_raw_event(struct hid_device *hdev, struct hid_report *report,
 		 * If report contains fragmented high-resolution pen
 		 * coordinates
 		 */
-		if (size >= 10 && params->pen_report_fragmented_hires) {
+		if (size >= 10 && params->pen_fragmented_hires) {
 			u8 pressure_low_byte;
 			u8 pressure_high_byte;
 
@@ -269,8 +268,7 @@ static int uclogic_raw_event(struct hid_device *hdev, struct hid_report *report,
 			data[9] = pressure_high_byte;
 		}
 		/* If we need to emulate proximity */
-		if (params->pen_report_inrange ==
-				UCLOGIC_PARAMS_PEN_REPORT_INRANGE_NONE) {
+		if (params->pen_inrange == UCLOGIC_PARAMS_PEN_INRANGE_NONE) {
 			/* Set proximity bit */
 			data[1] |= 0x40;
 			/* (Re-)start proximity timeout */

--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -65,9 +65,12 @@ static __u8 *uclogic_report_fixup(struct hid_device *hdev, __u8 *rdesc,
 	return rdesc;
 }
 
-static int uclogic_input_mapping(struct hid_device *hdev, struct hid_input *hi,
-		struct hid_field *field, struct hid_usage *usage,
-		unsigned long **bit, int *max)
+static int uclogic_input_mapping(struct hid_device *hdev,
+				 struct hid_input *hi,
+				 struct hid_field *field,
+				 struct hid_usage *usage,
+				 unsigned long **bit,
+				 int *max)
 {
 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
 	struct uclogic_params *params = drvdata->params;
@@ -220,8 +223,9 @@ static int uclogic_resume(struct hid_device *hdev)
 }
 #endif
 
-static int uclogic_raw_event(struct hid_device *hdev, struct hid_report *report,
-			u8 *data, int size)
+static int uclogic_raw_event(struct hid_device *hdev,
+				struct hid_report *report,
+				u8 *data, int size)
 {
 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
 	struct uclogic_params *params = drvdata->params;
@@ -304,16 +308,26 @@ static const struct hid_device_id uclogic_devices[] = {
 				USB_DEVICE_ID_UCLOGIC_WIRELESS_TABLET_TWHL850) },
 	{ HID_USB_DEVICE(USB_VENDOR_ID_UCLOGIC,
 				USB_DEVICE_ID_UCLOGIC_TABLET_TWHA60) },
-	{ HID_USB_DEVICE(USB_VENDOR_ID_HUION, USB_DEVICE_ID_HUION_TABLET) },
-	{ HID_USB_DEVICE(USB_VENDOR_ID_UCLOGIC, USB_DEVICE_ID_HUION_TABLET) },
-	{ HID_USB_DEVICE(USB_VENDOR_ID_UCLOGIC, USB_DEVICE_ID_YIYNOVA_TABLET) },
-	{ HID_USB_DEVICE(USB_VENDOR_ID_UCLOGIC, USB_DEVICE_ID_UCLOGIC_UGEE_TABLET_81) },
-	{ HID_USB_DEVICE(USB_VENDOR_ID_UCLOGIC, USB_DEVICE_ID_UCLOGIC_UGEE_TABLET_45) },
-	{ HID_USB_DEVICE(USB_VENDOR_ID_UCLOGIC, USB_DEVICE_ID_UCLOGIC_UGEE_TABLET_47) },
-	{ HID_USB_DEVICE(USB_VENDOR_ID_UCLOGIC, USB_DEVICE_ID_UCLOGIC_DRAWIMAGE_G3) },
-	{ HID_USB_DEVICE(USB_VENDOR_ID_UGTIZER, USB_DEVICE_ID_UGTIZER_TABLET_GP0610) },
-	{ HID_USB_DEVICE(USB_VENDOR_ID_UGEE, USB_DEVICE_ID_UGEE_TABLET_EX07S) },
-	{ HID_USB_DEVICE(USB_VENDOR_ID_UGEE, USB_DEVICE_ID_UGEE_XPPEN_TABLET_G540) },
+	{ HID_USB_DEVICE(USB_VENDOR_ID_HUION,
+				USB_DEVICE_ID_HUION_TABLET) },
+	{ HID_USB_DEVICE(USB_VENDOR_ID_UCLOGIC,
+				USB_DEVICE_ID_HUION_TABLET) },
+	{ HID_USB_DEVICE(USB_VENDOR_ID_UCLOGIC,
+				USB_DEVICE_ID_YIYNOVA_TABLET) },
+	{ HID_USB_DEVICE(USB_VENDOR_ID_UCLOGIC,
+				USB_DEVICE_ID_UCLOGIC_UGEE_TABLET_81) },
+	{ HID_USB_DEVICE(USB_VENDOR_ID_UCLOGIC,
+				USB_DEVICE_ID_UCLOGIC_UGEE_TABLET_45) },
+	{ HID_USB_DEVICE(USB_VENDOR_ID_UCLOGIC,
+				USB_DEVICE_ID_UCLOGIC_UGEE_TABLET_47) },
+	{ HID_USB_DEVICE(USB_VENDOR_ID_UCLOGIC,
+				USB_DEVICE_ID_UCLOGIC_DRAWIMAGE_G3) },
+	{ HID_USB_DEVICE(USB_VENDOR_ID_UGTIZER,
+				USB_DEVICE_ID_UGTIZER_TABLET_GP0610) },
+	{ HID_USB_DEVICE(USB_VENDOR_ID_UGEE,
+				USB_DEVICE_ID_UGEE_TABLET_EX07S) },
+	{ HID_USB_DEVICE(USB_VENDOR_ID_UGEE,
+				USB_DEVICE_ID_UGEE_XPPEN_TABLET_G540) },
 	{ }
 };
 MODULE_DEVICE_TABLE(hid, uclogic_devices);

--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -236,7 +236,7 @@ static int uclogic_raw_event(struct hid_device *hdev, struct hid_report *report,
 		/* If it's the "virtual" frame controls report */
 		if (data[1] & params->pen_report_frame_flag) {
 			/* Change to virtual frame controls report ID */
-			data[0] = params->pen_frame_report_id;
+			data[0] = params->frame_report_id;
 			return 0;
 		}
 		/* If in-range reports are inverted */

--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -174,7 +174,7 @@ static int uclogic_probe(struct hid_device *hdev,
 	/* Initialize the device and retrieve parameters */
 	rc = uclogic_params_probe(&drvdata->params, hdev);
 	if (rc != 0) {
-		hid_err(hdev, "failed probing parameters\n");
+		hid_err(hdev, "failed probing parameters: %d\n", rc);
 		goto failure;
 	}
 	if (drvdata->params == NULL) {

--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -183,7 +183,8 @@ static int uclogic_probe(struct hid_device *hdev,
 		rc = -ENODEV;
 		goto failure;
 	} else {
-		uclogic_params_dump(drvdata->params, hdev, "parameters:\n");
+		hid_dbg(hdev, "parameters:\n" UCLOGIC_PARAMS_FMT_STR,
+			UCLOGIC_PARAMS_FMT_ARGS(drvdata->params));
 	}
 
 	rc = hid_parse(hdev);

--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -16,6 +16,7 @@
 #include <linux/hid.h>
 #include <linux/module.h>
 #include <linux/usb.h>
+#include <linux/timer.h>
 #include <asm/unaligned.h>
 #include "usbhid/usbhid.h"
 #include "hid-uclogic-params.h"
@@ -29,8 +30,30 @@
 
 /* Driver data */
 struct uclogic_drvdata {
+	/* Interface parameters */
 	struct uclogic_params *params;
+	/* Pen input device */
+	struct input_dev *pen_input;
+	/* Proximity-out timer */
+	struct timer_list proximity_timer;
 };
+
+static void uclogic_proximity_timeout(struct timer_list *t)
+{
+	struct uclogic_drvdata *drvdata = from_timer(drvdata, t,
+							proximity_timer);
+	struct input_dev *input = drvdata->pen_input;
+	input_report_abs(input, ABS_PRESSURE, 0);
+	/* If BTN_TOUCH state is changing */
+	if (test_bit(BTN_TOUCH, input->key)) {
+		input_event(input, EV_MSC, MSC_SCAN,
+				/* Digitizer Tip Switch usage */
+				0xd0042);
+		input_report_key(input, BTN_TOUCH, 0);
+	}
+	input_report_key(input, BTN_TOOL_PEN, 0);
+	input_sync(input);
+}
 
 static __u8 *uclogic_report_fixup(struct hid_device *hdev, __u8 *rdesc,
 					unsigned int *rsize)
@@ -70,6 +93,8 @@ static int uclogic_input_configured(struct hid_device *hdev,
 		struct hid_input *hi)
 #endif
 {
+	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
+	struct uclogic_params *params = drvdata->params;
 	char *name;
 	const char *suffix = NULL;
 	struct hid_field *field;
@@ -78,6 +103,15 @@ static int uclogic_input_configured(struct hid_device *hdev,
 	/* no report associated (HID_QUIRK_MULTI_INPUT not set) */
 	if (!hi->report)
 		RETURN_SUCCESS;
+
+	/*
+	 * If this is the input corresponding to the pen report
+	 * in need of tweaking.
+	 */
+	if (hi->report->id == params->pen_report_id) {
+		/* Remember the input device so we can simulate events */
+		drvdata->pen_input = hi->input;
+	}
 
 	field = hi->report->field[0];
 
@@ -134,6 +168,7 @@ static int uclogic_probe(struct hid_device *hdev,
 		rc = -ENOMEM;
 		goto failure;
 	}
+	timer_setup(&drvdata->proximity_timer, uclogic_proximity_timeout, 0);
 	hid_set_drvdata(hdev, drvdata);
 
 	/* Initialize the device and retrieve parameters */
@@ -202,38 +237,47 @@ static int uclogic_raw_event(struct hid_device *hdev, struct hid_report *report,
 		if (data[1] & params->pen_report_frame_flag) {
 			/* Change to virtual frame controls report ID */
 			data[0] = params->pen_frame_report_id;
-		} else {
-			/* If in-range reports are inverted */
-			if (params->pen_report_inrange ==
-				UCLOGIC_PARAMS_PEN_REPORT_INRANGE_INVERTED) {
-				/* Invert the in-range bit */
-				data[1] ^= 0x40;
-			}
-			/*
-			 * If report contains fragmented high-resolution pen
-			 * coordinates
-			 */
-			if (size >= 10 && params->pen_report_fragmented_hires) {
-				u8 pressure_low_byte;
-				u8 pressure_high_byte;
+			return 0;
+		}
+		/* If in-range reports are inverted */
+		if (params->pen_report_inrange ==
+			UCLOGIC_PARAMS_PEN_REPORT_INRANGE_INVERTED) {
+			/* Invert the in-range bit */
+			data[1] ^= 0x40;
+		}
+		/*
+		 * If report contains fragmented high-resolution pen
+		 * coordinates
+		 */
+		if (size >= 10 && params->pen_report_fragmented_hires) {
+			u8 pressure_low_byte;
+			u8 pressure_high_byte;
 
-				/* Lift pressure bytes */
-				pressure_low_byte = data[6];
-				pressure_high_byte = data[7];
-				/*
-				 * Move Y coord to make space for high-order X
-				 * coord byte
-				 */
-				data[6] = data[5];
-				data[5] = data[4];
-				/* Move high-order X coord byte */
-				data[4] = data[8];
-				/* Move high-order Y coord byte */
-				data[7] = data[9];
-				/* Place pressure bytes */
-				data[8] = pressure_low_byte;
-				data[9] = pressure_high_byte;
-			}
+			/* Lift pressure bytes */
+			pressure_low_byte = data[6];
+			pressure_high_byte = data[7];
+			/*
+			 * Move Y coord to make space for high-order X
+			 * coord byte
+			 */
+			data[6] = data[5];
+			data[5] = data[4];
+			/* Move high-order X coord byte */
+			data[4] = data[8];
+			/* Move high-order Y coord byte */
+			data[7] = data[9];
+			/* Place pressure bytes */
+			data[8] = pressure_low_byte;
+			data[9] = pressure_high_byte;
+		}
+		/* If we need to emulate proximity */
+		if (params->pen_report_inrange ==
+				UCLOGIC_PARAMS_PEN_REPORT_INRANGE_NONE) {
+			/* Set proximity bit */
+			data[1] |= 0x40;
+			/* (Re-)start proximity timeout */
+			mod_timer(&drvdata->proximity_timer,
+					jiffies + msecs_to_jiffies(100));
 		}
 	}
 
@@ -243,9 +287,10 @@ static int uclogic_raw_event(struct hid_device *hdev, struct hid_report *report,
 static void uclogic_remove(struct hid_device *hdev)
 {
 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
+	del_timer_sync(&drvdata->proximity_timer);
+	hid_hw_stop(hdev);
 	uclogic_params_free(drvdata->params);
 	drvdata->params = NULL;
-	hid_hw_stop(hdev);
 }
 
 static const struct hid_device_id uclogic_devices[] = {

--- a/hid-uclogic-params.c
+++ b/hid-uclogic-params.c
@@ -537,6 +537,9 @@ void uclogic_params_free(struct uclogic_params *params)
  * 		Can be NULL to have parameters discarded after retrieval.
  * @hdev	The HID device of the tablet interface to initialize and
  * 		possibly get parameters from. Cannot be NULL.
+ *
+ * Return:
+ * 	Zero, if successful. A negative errno code on error.
  */
 static int uclogic_params_probe_static(struct uclogic_params **pparams,
 			 		struct hid_device *hdev)

--- a/hid-uclogic-params.c
+++ b/hid-uclogic-params.c
@@ -462,9 +462,9 @@ static int uclogic_params_frame_probe_generic(
 	if (rc == -EPIPE) {
 		hid_dbg(hdev, "generic button -enabling string descriptor "
 				"not found\n");
-	} else if (rc < 0) {
+	} else if (rc < 0 && rc != -ENODATA) {
 		goto cleanup;
-	} else if (strncmp(str_buf, "HK On", rc) != 0) {
+	} else if (rc == 0 && strncmp(str_buf, "HK On", rc) != 0) {
 		hid_dbg(hdev, "invalid response to enabling generic "
 				"buttons: \"%s\"\n", str_buf);
 	} else {
@@ -472,7 +472,13 @@ static int uclogic_params_frame_probe_generic(
 			[UCLOGIC_RDESC_BUTTONPAD_PH_ID_PADDING] = padding
 		};
 
-		hid_dbg(hdev, "generic buttons enabled\n");
+		if (rc == -ENODATA) {
+			hid_dbg(hdev, "invalid generic button -enabling string "
+					"descriptor, assuming generic buttons "
+					"are enabled succesfully\n");
+		} else {
+			hid_dbg(hdev, "generic buttons enabled\n");
+		}
 
 		frame = kzalloc(sizeof(*frame), GFP_KERNEL);
 		if (frame == NULL) {

--- a/hid-uclogic-params.c
+++ b/hid-uclogic-params.c
@@ -97,7 +97,6 @@ cleanup:
 }
 
 /* Tablet interface's pen input parameters */
-/* TODO Consider stripping "report" from names */
 struct uclogic_params_pen {
 	/* Pointer to report descriptor allocated with kmalloc */
 	__u8 *desc_ptr;

--- a/hid-uclogic-params.c
+++ b/hid-uclogic-params.c
@@ -851,6 +851,50 @@ cleanup:
 }
 
 /**
+ * uclogic_params_dump() - dump tablet interface parameters with hid_dbg.
+ *
+ * @params 	The interface parameters to dump. Cannot be NULL.
+ * @hdev	The HID device of the tablet interface to refer to while
+ * 		dumping. Cannot be NULL.
+ * @prefix   	String to output before the dump. Cannot be NULL.
+ */
+void uclogic_params_dump(const struct uclogic_params *params,
+				const struct hid_device *hdev,
+				const char *prefix)
+{
+#define BOOL_STR(_x) ((_x) ? "true" : "false")
+#define INRANGE_STR(_x) \
+	((_x) == UCLOGIC_PARAMS_PEN_REPORT_INRANGE_NORMAL \
+		? "normal" \
+		: ((_x) == UCLOGIC_PARAMS_PEN_REPORT_INRANGE_INVERTED \
+			? "inverted" \
+			: "none"))
+
+	hid_dbg(hdev,
+		"%s"
+		".rdesc_ptr = %p\n"
+		".rdesc_size = %u\n"
+		".pen_unused = %s\n"
+		".pen_report_id = %u\n"
+		".pen_report_inrange = %s\n"
+		".pen_report_frame_flag = 0x%02x\n"
+		".pen_report_fragmented_hires = %s\n"
+		".frame_virtual_report_id = %u\n",
+		prefix,
+		params->rdesc_ptr,
+		params->rdesc_size,
+		BOOL_STR(params->pen_unused),
+		params->pen_report_id,
+		INRANGE_STR(params->pen_report_inrange),
+		params->pen_report_frame_flag,
+		BOOL_STR(params->pen_report_fragmented_hires),
+		params->frame_virtual_report_id);
+
+#undef INRANGE_STR
+#undef BOOL_STR
+}
+
+/**
  * uclogic_params_probe() - initialize a tablet interface and discover its
  * parameters.
  *

--- a/hid-uclogic-params.c
+++ b/hid-uclogic-params.c
@@ -716,8 +716,8 @@ static int uclogic_params_with_opt_desc(struct uclogic_params **pparams,
 		goto cleanup;
 	}
 
-	/* Replace matching report descriptor */
-	if (hdev->rsize == orig_desc_size) {
+	/* Replace report descriptor, if it matches */
+	if (hdev->dev_rsize == orig_desc_size) {
 		params->desc_ptr = kmemdup(desc_ptr, desc_size, GFP_KERNEL);
 		if (params->desc_ptr == NULL) {
 			rc = -ENOMEM;

--- a/hid-uclogic-params.c
+++ b/hid-uclogic-params.c
@@ -20,6 +20,29 @@
 #include <asm/unaligned.h>
 
 /**
+ * Convert a pen in-range reporting type to a string.
+ *
+ * @inrange:	The in-range reporting type to convert.
+ *
+ * Return:
+ * 	The string representing the type, or NULL if the type is unknown.
+ */
+const char *uclogic_params_pen_inrange_to_str(
+			enum uclogic_params_pen_inrange inrange)
+{
+	switch (inrange) {
+	case UCLOGIC_PARAMS_PEN_INRANGE_NORMAL:
+		return "normal";
+	case UCLOGIC_PARAMS_PEN_INRANGE_INVERTED:
+		return "inverted";
+	case UCLOGIC_PARAMS_PEN_INRANGE_NONE:
+		return "none";
+	default:
+		return NULL;
+	}
+}
+
+/**
  * uclogic_params_get_str_desc - retrieve a string descriptor from a HID
  * device interface, putting it into a kmalloc-allocated buffer as is, without
  * character encoding conversion.
@@ -746,52 +769,6 @@ static int uclogic_params_with_pen_unused(struct uclogic_params **pparams)
 cleanup:
 	uclogic_params_free(params);
 	return rc;
-}
-
-/**
- * uclogic_params_dump() - dump tablet interface parameters with hid_dbg.
- *
- * @params: 	The interface parameters to dump. Cannot be NULL.
- * @hdev:	The HID device of the tablet interface to refer to while
- * 		dumping. Cannot be NULL.
- * @prefix:   	String to output before the dump. Cannot be NULL.
- */
-void uclogic_params_dump(const struct uclogic_params *params,
-				const struct hid_device *hdev,
-				const char *prefix)
-{
-#define BOOL_STR(_x) ((_x) ? "true" : "false")
-#define INRANGE_STR(_x) \
-	((_x) == UCLOGIC_PARAMS_PEN_INRANGE_NORMAL \
-		? "normal" \
-		: ((_x) == UCLOGIC_PARAMS_PEN_INRANGE_INVERTED \
-			? "inverted" \
-			: ((_x) == UCLOGIC_PARAMS_PEN_INRANGE_NONE \
-				? "none" \
-				: "unknown")))
-
-	hid_dbg(hdev,
-		"%s"
-		".desc_ptr = %p\n"
-		".desc_size = %u\n"
-		".pen_unused = %s\n"
-		".pen_id = %u\n"
-		".pen_inrange = %s\n"
-		".pen_fragmented_hires = %s\n"
-		".pen_frame_flag = 0x%02x\n"
-		".pen_frame_id = %u\n",
-		prefix,
-		params->desc_ptr,
-		params->desc_size,
-		BOOL_STR(params->pen_unused),
-		params->pen_id,
-		INRANGE_STR(params->pen_inrange),
-		BOOL_STR(params->pen_fragmented_hires),
-		params->pen_frame_flag,
-		params->pen_frame_id);
-
-#undef INRANGE_STR
-#undef BOOL_STR
 }
 
 /**

--- a/hid-uclogic-params.c
+++ b/hid-uclogic-params.c
@@ -96,19 +96,23 @@ cleanup:
 	return rc;
 }
 
-/* Tablet interface's pen input parameters */
+/*
+ * Tablet interface's pen input parameters.
+ * Noop (preserving functionality) when filled with zeroes.
+ */
 struct uclogic_params_pen {
 	/* Pointer to report descriptor allocated with kmalloc */
 	__u8 *desc_ptr;
 	/* Size of the report descriptor */
 	unsigned int desc_size;
-	/* Pen report ID */
+	/* Report ID, if reports should be tweaked, zero if not */
 	unsigned id;
-	/* Type of pen in-range reporting */
+	/* Type of in-range reporting, only valid if id is not zero */
 	enum uclogic_params_pen_inrange inrange;
 	/*
-	 * True, if pen reports include fragmented high resolution coords,
-	 * with high-order X and then Y bytes following the pressure field
+	 * True, if reports include fragmented high resolution coords, with
+	 * high-order X and then Y bytes following the pressure field.
+	 * Only valid if id is not zero.
 	 */
 	bool fragmented_hires;
 };
@@ -415,7 +419,10 @@ cleanup:
 	return rc;
 }
 
-/* Parameters of frame control inputs of a tablet interface */
+/*
+ * Parameters of frame control inputs of a tablet interface.
+ * Noop (preserving functionality) when filled with zeroes.
+ */
 struct uclogic_params_frame {
 	/* Pointer to report descriptor allocated with kmalloc */
 	__u8 *desc_ptr;
@@ -974,6 +981,7 @@ int uclogic_params_probe(struct uclogic_params **pparams,
 		break;
 	case USB_DEVICE_ID_UGTIZER_TABLET_GP0610:
 	case USB_DEVICE_ID_UGEE_XPPEN_TABLET_G540:
+		/* If this is the pen interface */
 		if (bInterfaceNumber == 1) {
 			rc = uclogic_params_pen_v1_probe(&pen, hdev);
 			if (rc != 0) {

--- a/hid-uclogic-params.c
+++ b/hid-uclogic-params.c
@@ -24,11 +24,11 @@
  * device interface, putting it into a kmalloc-allocated buffer as is, without
  * character encoding conversion.
  *
- * @pbuf	Location for the kmalloc-allocated buffer pointer containing
+ * @pbuf:	Location for the kmalloc-allocated buffer pointer containing
  * 		the retrieved descriptor. Not modified in case of error.
  * 		Can be NULL to have retrieved descriptor discarded.
- * @idx		Index of the string descriptor to request from the device.
- * @len		Length of the buffer to allocate and the data to retrieve.
+ * @idx:	Index of the string descriptor to request from the device.
+ * @len:	Length of the buffer to allocate and the data to retrieve.
  *
  * Return:
  * 	number of bytes retrieved (<= len),
@@ -95,7 +95,7 @@ struct uclogic_params_pen {
  * uclogic_params_pen_free - free resources used by struct uclogic_params_pen
  * (tablet interface's pen input parameters).
  *
- * @pen	Pen input parameters to free. Can be NULL.
+ * @pen:	Pen input parameters to free. Can be NULL.
  */
 static void uclogic_params_pen_free(struct uclogic_params_pen *pen)
 {
@@ -110,12 +110,12 @@ static void uclogic_params_pen_free(struct uclogic_params_pen *pen)
  * uclogic_params_pen_v1_probe() - initialize tablet interface pen
  * input and retrieve its parameters from the device, using v1 protocol.
  *
- * @ppen 	Location for the pointer to resulting pen parameters (to be
+ * @ppen: 	Location for the pointer to resulting pen parameters (to be
  * 		freed with uclogic_params_pen_free()), or for NULL if the pen
  * 		parameters were not found or recognized.  Not modified in case
  * 		of error. Can be NULL to have parameters discarded after
  * 		retrieval.
- * @hdev	The HID device of the tablet interface to initialize and get
+ * @hdev:	The HID device of the tablet interface to initialize and get
  * 		parameters from. Cannot be NULL.
  *
  * Return:
@@ -237,7 +237,7 @@ cleanup:
  * uclogic_params_get_le24() - get a 24-bit little-endian number from a
  * buffer.
  *
- * @p	The pointer to the number buffer.
+ * @p:	The pointer to the number buffer.
  *
  * Return:
  * 	The retrieved number
@@ -252,12 +252,12 @@ static s32 uclogic_params_get_le24(const void *p)
  * uclogic_params_pen_v2_probe() - initialize tablet interface pen
  * input and retrieve its parameters from the device, using v2 protocol.
  *
- * @ppen 	Location for the pointer to resulting pen parameters (to be
+ * @ppen: 	Location for the pointer to resulting pen parameters (to be
  * 		freed with uclogic_params_pen_free()), or for NULL if the pen
  * 		parameters were not found or recognized.  Not modified in case
  * 		of error. Can be NULL to have parameters discarded after
  * 		retrieval.
- * @hdev	The HID device of the tablet interface to initialize and get
+ * @hdev:	The HID device of the tablet interface to initialize and get
  * 		parameters from. Cannot be NULL.
  *
  * Return:
@@ -409,7 +409,7 @@ struct uclogic_params_frame {
  * uclogic_params_frame_free - free resources used by struct
  * uclogic_params_frame (tablet interface's frame controls input parameters).
  *
- * @frame	Frame controls input parameters to free. Can be NULL.
+ * @frame:	Frame controls input parameters to free. Can be NULL.
  */
 static void uclogic_params_frame_free(struct uclogic_params_frame *frame)
 {
@@ -424,15 +424,15 @@ static void uclogic_params_frame_free(struct uclogic_params_frame *frame)
  * uclogic_params_frame_probe_generic() - initialize tablet interface generic
  * frame button controls, with specified bit layout.
  *
- * @pframe		Location for the pointer to resulting frame controls
+ * @pframe:		Location for the pointer to resulting frame controls
  * 			parameters (to be freed with
  * 			uclogic_params_frame_free()), or for NULL if the frame
  * 			controls parameters were not found or recognized.  Not
  * 			modified in case of error. Can be NULL to have
  * 			parameters discarded after retrieval.
- * @hdev		The HID device of the tablet interface to initialize
+ * @hdev:		The HID device of the tablet interface to initialize
  * 			and get parameters from. Cannot be NULL.
- * @padding		Padding from the end of button bits at bit 44, until
+ * @padding:		Padding from the end of button bits at bit 44, until
  * 			the end of the report, bits.
  *
  * Return:
@@ -516,7 +516,7 @@ cleanup:
  * uclogic_params_free - free resources used by struct uclogic_params
  * (tablet interface's input parameters).
  *
- * @params	Input parameters to free. Can be NULL.
+ * @params:	Input parameters to free. Can be NULL.
  */
 void uclogic_params_free(struct uclogic_params *params)
 {
@@ -531,11 +531,11 @@ void uclogic_params_free(struct uclogic_params *params)
  * uclogic_params_probe_static() - probe a tablet interface with
  * statically-assigned parameters.
  *
- * @pparams 	Location for the pointer to resulting parameters (to be
+ * @pparams: 	Location for the pointer to resulting parameters (to be
  * 		freed with uclogic_params_free()), or for NULL if the
  * 		parameters were not found.  Not modified in case of error.
  * 		Can be NULL to have parameters discarded after retrieval.
- * @hdev	The HID device of the tablet interface to initialize and
+ * @hdev:	The HID device of the tablet interface to initialize and
  * 		possibly get parameters from. Cannot be NULL.
  *
  * Return:
@@ -713,11 +713,11 @@ cleanup:
  * uclogic_params_probe_dynamic() - initialize a tablet interface and retrieve
  * its parameters from the device.
  *
- * @pparams 	Location for the pointer to resulting parameters (to be
+ * @pparams: 	Location for the pointer to resulting parameters (to be
  * 		freed with uclogic_params_free()), or for NULL if the
  * 		parameters were not found.  Not modified in case of error.
  * 		Can be NULL to have parameters discarded after retrieval.
- * @hdev	The HID device of the tablet interface to initialize and get
+ * @hdev:	The HID device of the tablet interface to initialize and get
  * 		parameters from. Cannot be NULL.
  *
  * Return:
@@ -904,10 +904,10 @@ cleanup:
 /**
  * uclogic_params_dump() - dump tablet interface parameters with hid_dbg.
  *
- * @params 	The interface parameters to dump. Cannot be NULL.
- * @hdev	The HID device of the tablet interface to refer to while
+ * @params: 	The interface parameters to dump. Cannot be NULL.
+ * @hdev:	The HID device of the tablet interface to refer to while
  * 		dumping. Cannot be NULL.
- * @prefix   	String to output before the dump. Cannot be NULL.
+ * @prefix:   	String to output before the dump. Cannot be NULL.
  */
 void uclogic_params_dump(const struct uclogic_params *params,
 				const struct hid_device *hdev,
@@ -951,11 +951,11 @@ void uclogic_params_dump(const struct uclogic_params *params,
  * uclogic_params_probe() - initialize a tablet interface and discover its
  * parameters.
  *
- * @pparams 	Location for the pointer to resulting parameters (to be
+ * @pparams: 	Location for the pointer to resulting parameters (to be
  * 		freed with uclogic_params_free()), or for NULL if the
  * 		parameters were not found.  Not modified in case of error.
  * 		Can be NULL to have parameters discarded after retrieval.
- * @hdev	The HID device of the tablet interface to initialize and get
+ * @hdev:	The HID device of the tablet interface to initialize and get
  * 		parameters from. Cannot be NULL.
  *
  * Return:

--- a/hid-uclogic-params.c
+++ b/hid-uclogic-params.c
@@ -315,12 +315,13 @@ static int uclogic_params_pen_v2_probe(struct uclogic_params_pen **ppen,
 		 */
 		for (i = 2;
 		     i < len &&
-		     	!(buf[i] >= 0x20 && buf[i] < 0x7f && buf[i + 1] == 0);
+			(buf[i] >= 0x20 && buf[i] < 0x7f && buf[i + 1] == 0);
 		     i += 2);
-		if (i < len) {
+		if (i >= len) {
 			hid_dbg(hdev,
-				"string descriptor with pen parameters seems "
-				"to contain text, assuming not compatible\n");
+				"string descriptor with pen parameters "
+				"seems to contain only text, "
+				"assuming not compatible\n");
 			goto output;
 		}
 	}

--- a/hid-uclogic-params.c
+++ b/hid-uclogic-params.c
@@ -1,0 +1,837 @@
+/*
+ *  HID driver for UC-Logic devices not fully compliant with HID standard
+ *  - tablet initialization and parameter retrieval
+ *
+ *  Copyright (c) 2018 Nikolai Kondrashov
+ */
+
+/*
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ */
+
+#include "hid-uclogic-params.h"
+#include "hid-uclogic-rdesc.h"
+#include <ctype.h>
+
+/**
+ * uclogic_params_get_str_desc - retrieve a string descriptor from a HID
+ * device interface, putting it into a kmalloc-allocated buffer as is, without
+ * character encoding conversion.
+ *
+ * @pbuf	Location for the kmalloc-allocated buffer pointer containing
+ * 		the retrieved descriptor. Not modified in case of error.
+ * @idx		Index of the string descriptor to request from the device.
+ * @len		Length of the buffer to allocate and the data to retrieve.
+ *
+ * Return:
+ * 	number of bytes retrieved (<= len),
+ * 	-EPIPE, if the descriptor was not found, or
+ *	another negative errno code in case of other error.
+ */
+static int uclogic_params_get_str_desc(__u8 **pbuf, struct hid_device *hdev,
+					__u8 idx, size_t len)
+{
+	int rc;
+	struct usb_device *udev = hid_to_usb_dev(hdev);
+	__u8 *buf;
+
+	buf = kmalloc(len, GFP_KERNEL);
+	if (buf == NULL) {
+		return -ENOMEM;
+	}
+	rc = usb_control_msg(udev, usb_rcvctrlpipe(udev, 0),
+				USB_REQ_GET_DESCRIPTOR, USB_DIR_IN,
+				(USB_DT_STRING << 8) + idx,
+				0x0409, buf, len,
+				USB_CTRL_GET_TIMEOUT);
+	if (rc >= 0) {
+		*pbuf = buf;
+	} else {
+		kfree(buf);
+	}
+	return rc;
+}
+
+/* Tablet interface's pen input parameters */
+struct uclogic_params_pen {
+	/* Pointer to report descriptor allocated with kmalloc */
+	__u8 *rdesc_ptr;
+	/* Size of the report descriptor */
+	unsigned int rdesc_size;
+	/* Pen report ID */
+	unsigned report_id;
+	/*
+	 * True, if pen reports include fragmented high resolution coords,
+	 * with high-order X and then Y bytes following the pressure field
+	 */
+	bool report_fragmented_hires;
+};
+
+/**
+ * uclogic_params_pen_free - free resources used by struct uclogic_params_pen
+ * (tablet interface's pen input parameters).
+ *
+ * @pen	Pen input parameters to free. Can be NULL.
+ */
+static void uclogic_params_pen_free(struct uclogic_params_pen *pen)
+{
+	if (pen != NULL) {
+		kfree(pen->rdesc_ptr);
+		memset(pen, 0, sizeof(*pen));
+	}
+}
+
+/**
+ * uclogic_params_pen_v1_probe() - initialize tablet interface pen
+ * input and retrieve its parameters from the device, using v1 protocol.
+ *
+ * @ppen 	Location for the pointer to resulting pen parameters (to be
+ * 		freed with uclogic_params_pen_free()), or for NULL if the pen
+ * 		parameters were not found or recognized.  Not modified in case
+ * 		of error. Can be NULL to have parameters discarded after
+ * 		retrieval.
+ * @hdev	The HID device of the tablet interface to initialize and get
+ * 		parameters from. Cannot be NULL.
+ *
+ * Return:
+ * 	Zero, if successful. A negative errno code on error.
+ */
+static int uclogic_params_pen_v1_probe(struct uclogic_params_pen **ppen,
+					struct hid_device *hdev)
+{
+	int rc;
+	/* Buffer for (part of) the string descriptor */
+	__u8 *buf = NULL;
+	/* Minimum descriptor length required, maximum seen so far is 18 */
+	const size_t len = 12;
+	s32 resolution;
+	/* Pen report descriptor template parameters */
+	s32 rdesc_params[UCLOGIC_RDESC_PEN_PH_ID_NUM];
+	__u8 *rdesc_ptr = NULL;
+	struct uclogic_params_pen *pen = NULL;
+
+	/* Check arguments */
+	if (hdev == NULL) {
+		rc = -EINVAL;
+		goto cleanup;
+	}
+
+	/*
+	 * Read string descriptor containing pen input parameters.
+	 * The specific string descriptor and data were discovered by sniffing
+	 * the Windows driver traffic.
+	 * NOTE: This enables fully-functional tablet mode.
+	 */
+	rc = uclogic_params_get_str_desc(&buf, hdev, 100, len);
+	if (rc < 0) {
+		goto cleanup;
+	} else if (rc != len) {
+		rc = -ERANGE;
+		goto cleanup;
+	}
+
+	/*
+	 * Fill report descriptor parameters from the string descriptor
+	 */
+	rdesc_params[UCLOGIC_RDESC_PEN_PH_ID_X_LM] =
+		le16_to_cpu((__le16 *)(buf + 2))
+	rdesc_params[UCLOGIC_RDESC_PEN_PH_ID_Y_LM] =
+		le16_to_cpu((__le16 *)(buf + 4))
+	rdesc_params[UCLOGIC_RDESC_PEN_PH_ID_PRESSURE_LM] =
+		le16_to_cpu((__le16 *)(buf + 8))
+	resolution = le16_to_cpu((__le16 *)(buf + 10));
+	if (resolution == 0) {
+		rdesc_params[UCLOGIC_RDESC_PEN_PH_ID_X_PM] = 0;
+		rdesc_params[UCLOGIC_RDESC_PEN_PH_ID_Y_PM] = 0;
+	} else {
+		rdesc_params[UCLOGIC_RDESC_PEN_PH_ID_X_PM] =
+			rdesc_params[UCLOGIC_RDESC_PEN_PH_ID_X_LM] * 1000 /
+			resolution;
+		rdesc_params[UCLOGIC_RDESC_PEN_PH_ID_Y_PM] =
+			rdesc_params[UCLOGIC_RDESC_PEN_PH_ID_Y_LM] * 1000 /
+			resolution;
+	}
+	kfree(buf);
+	buf = NULL;
+
+	/*
+	 * Generate pen report descriptor
+	 */
+	rdesc_ptr = uclogic_rdesc_template_fill(
+				uclogic_rdesc_pen_v1_template_arr,
+				uclogic_rdesc_pen_v1_template_size,
+				rdesc_params, ARRAY_SIZE(rdesc_params));
+	if (rdesc_ptr == NULL) {
+		rc = -ENOMEM;
+		goto cleanup;
+	}
+
+	/*
+	 * Fill-in the parameters
+	 */
+	pen = kzalloc(sizeof(*pen), GFP_KERNEL);
+	if (pen == NULL) {
+		rc = -ENOMEM;
+		goto cleanup;
+	}
+	pen->rdesc_ptr = rdesc_ptr;
+	rdesc_ptr = NULL;
+	pen->rdesc_size = uclogic_rdesc_pen_v1_template_size;
+	pen->report_id = UCLOGIC_RDESC_PEN_V1_ID;
+
+	/*
+	 * Output the parameters, if requested
+	 */
+	if (ppen != NULL) {
+		*ppen = pen;
+		pen = NULL;
+	}
+
+	rc = 0;
+
+cleanup:
+	uclogic_params_pen_free(pen);
+	kfree(rdesc_ptr);
+	kfree(buf);
+	return rc;
+}
+
+/**
+ * uclogic_params_le24_to_cpu - convert a 24-bit number from little-endian to
+ * host byte order.
+ *
+ * @p	The pointer to the number to convert.
+ *
+ * Return:
+ * 	The converted number
+ */
+static s32 uclogic_params_le24_to_cpu(const __u8* p)
+{
+	return p[0] | (p[1] << 8UL) | (p[2] << 16UL);
+}
+
+/**
+ * uclogic_params_pen_v2_probe() - initialize tablet interface pen
+ * input and retrieve its parameters from the device, using v2 protocol.
+ *
+ * @ppen 	Location for the pointer to resulting pen parameters (to be
+ * 		freed with uclogic_params_pen_free()), or for NULL if the pen
+ * 		parameters were not found or recognized.  Not modified in case
+ * 		of error. Can be NULL to have parameters discarded after
+ * 		retrieval.
+ * @hdev	The HID device of the tablet interface to initialize and get
+ * 		parameters from. Cannot be NULL.
+ *
+ * Return:
+ * 	Zero, if successful. A negative errno code on error.
+ */
+static int uclogic_params_pen_v2_probe(struct uclogic_params_pen **ppen,
+					struct hid_device *hdev)
+{
+	int rc;
+	/* Buffer for (part of) the string descriptor */
+	__u8 *buf = NULL;
+	/* Minimum descriptor length required, maximum seen so far is 18 */
+	const size_t len = 12;
+	s32 resolution;
+	/* Pen report descriptor template parameters */
+	s32 rdesc_params[UCLOGIC_RDESC_PEN_PH_ID_NUM];
+	__u8 *rdesc_ptr = NULL;
+	struct uclogic_params_pen *pen = NULL;
+
+	/* Check arguments */
+	if (hdev == NULL) {
+		rc = -EINVAL;
+		goto cleanup;
+	}
+
+	/*
+	 * Read string descriptor containing pen input parameters.
+	 * The specific string descriptor and data were discovered by sniffing
+	 * the Windows driver traffic.
+	 * NOTE: This enables fully-functional tablet mode.
+	 */
+	rc = uclogic_params_get_str_desc(&buf, hdev, 100, len);
+	if (rc < 0) {
+		goto cleanup;
+	} else if (rc != len) {
+		rc = -ERANGE;
+		goto cleanup;
+	} else {
+		size_t i;
+		/*
+		 * Check it's not just a catch-all UTF-16LE-encoded ASCII
+		 * string (such as the model name) some tablets put into all
+		 * unknown string descriptors.
+		 */
+		for (i = 2;
+		     i < len &&
+		     	!(buf[i] >= 0x20 && buf[i] < 0x7f && buf[i + 1] == 0);
+		     i += 2);
+		if (i < len) {
+			rc = -ERANGE;
+			goto cleanup;
+		}
+	}
+
+	/*
+	 * Fill report descriptor parameters from the string descriptor
+	 */
+	rdesc_params[UCLOGIC_RDESC_PEN_PH_ID_X_LM] =
+		uclogic_params_le24_to_cpu(buf + 2)
+	rdesc_params[UCLOGIC_RDESC_PEN_PH_ID_Y_LM] =
+		uclogic_params_le24_to_cpu(buf + 5)
+	rdesc_params[UCLOGIC_RDESC_PEN_PH_ID_PRESSURE_LM] =
+		le16_to_cpu((__le16 *)(buf + 8))
+	resolution = le16_to_cpu((__le16 *)(buf + 10));
+	if (resolution == 0) {
+		rdesc_params[UCLOGIC_RDESC_PEN_PH_ID_X_PM] = 0;
+		rdesc_params[UCLOGIC_RDESC_PEN_PH_ID_Y_PM] = 0;
+	} else {
+		rdesc_params[UCLOGIC_RDESC_PEN_PH_ID_X_PM] =
+			rdesc_params[UCLOGIC_RDESC_PEN_PH_ID_X_LM] * 1000 /
+			resolution;
+		rdesc_params[UCLOGIC_RDESC_PEN_PH_ID_Y_PM] =
+			rdesc_params[UCLOGIC_RDESC_PEN_PH_ID_Y_LM] * 1000 /
+			resolution;
+	}
+	kfree(buf);
+	buf = NULL;
+
+	/*
+	 * Generate pen report descriptor
+	 */
+	rdesc_ptr = uclogic_rdesc_template_fill(
+				uclogic_rdesc_pen_v2_template_arr,
+				uclogic_rdesc_pen_v2_template_size,
+				rdesc_params, ARRAY_SIZE(rdesc_params));
+	if (rdesc_ptr == NULL) {
+		rc = -ENOMEM;
+		goto cleanup;
+	}
+
+	/*
+	 * Fill-in the parameters
+	 */
+	pen = kzalloc(sizeof(*pen), GFP_KERNEL);
+	if (pen == NULL) {
+		rc = -ENOMEM;
+		goto cleanup;
+	}
+	pen->rdesc_ptr = rdesc_ptr;
+	rdesc_ptr = NULL;
+	pen->rdesc_size = uclogic_rdesc_pen_v2_template_size;
+	pen->report_id = UCLOGIC_RDESC_PEN_V2_ID;
+	pen->report_fragmented_hires = true;
+
+	/*
+	 * Output the parameters, if requested
+	 */
+	if (ppen != NULL) {
+		*ppen = pen;
+		pen = NULL;
+	}
+
+	rc = 0;
+
+cleanup:
+	uclogic_params_pen_free(pen);
+	kfree(rdesc_ptr);
+	kfree(buf);
+	return rc;
+}
+
+/**
+ * uclogic_params_pen_probe() - initialize tablet interface pen
+ * input and retrieve its parameters from the device.
+ *
+ * @ppen 	Location for the pointer to resulting pen parameters (to be
+ * 		freed with uclogic_params_pen_free()), or for NULL if the pen
+ * 		parameters were not found or recognized.  Not modified in case
+ * 		of error. Can be NULL to have parameters discarded after
+ * 		retrieval.
+ * @hdev	The HID device of the tablet interface to initialize and get
+ * 		parameters from. Cannot be NULL.
+ *
+ * Return:
+ * 	Zero, if successful. A negative errno code on error.
+ */
+static int uclogic_params_pen_probe(struct uclogic_params_pen **ppen,
+					struct hid_device *hdev)
+{
+	int rc;
+	/* The resulting parameters */
+	struct uclogic_params_pen *pen = NULL;
+
+	/* Check arguments */
+	if (hdev == NULL) {
+		return -EINVAL;
+	}
+
+	/* Try to probe v2 pen parameters */
+	rc = uclogic_params_pen_v2_probe(&pen, hdev);
+	/* If this is not a v2 pen */
+	if (rc == 0 && &pen == NULL) {
+		/* Try to probe v1 pen parameters */
+		rc = uclogic_params_pen_v1_probe(&pen, hdev);
+	}
+
+	/* Output the parameters if succeeded, and asked to */
+	if (rc == 0 && ppen != NULL) {
+		*ppen = pen;
+		pen = NULL;
+	}
+
+	uclogic_params_pen_free(pen);
+	return rc;
+}
+
+/* Parameters of frame control inputs of a tablet interface */
+struct uclogic_params_frame {
+	/* Pointer to report descriptor allocated with kmalloc */
+	__u8 *rdesc_ptr;
+	/* Size of the report descriptor */
+	unsigned int rdesc_size;
+};
+
+/**
+ * uclogic_params_frame_cleanup - cleanup and free resources used by struct
+ * uclogic_params_frame (tablet interface's frame controls input parameters).
+ * Can be called repeatedly.
+ *
+ * @frame	Frame controls input parameters to cleanup.
+ */
+static void uclogic_params_frame_cleanup(struct uclogic_params_frame *frame)
+{
+	kfree(frame->rdesc_ptr);
+	memset(frame, 0, sizeof(*frame));
+}
+
+/**
+ * uclogic_params_frame_probe() - initialize tablet interface frame controls
+ * input and retrieve its parameters from the device.
+ *
+ * @frame 	Location for the resulting frame controls parameters.
+ * 		Needs to be cleaned up with uclogic_params_frame_cleanup()
+ * 		after use, if this function succeeds.
+ * @ppen 	Location for the pointer to resulting frame controls
+ * 		parameters (to be freed with uclogic_params_frame_free()), or
+ * 		for NULL if the frame controls parameters were not found or
+ * 		recognized.  Not modified in case of error. Can be NULL to
+ * 		have parameters discarded after retrieval.
+ * @hdev	The HID device of the tablet interface to initialize and get
+ * 		parameters from. Cannot be NULL.
+ *
+ * Return:
+ * 	Zero, if successful. A negative errno code on error.
+ */
+static int uclogic_params_frame_probe(struct uclogic_params_frame **pframe,
+					struct hid_device *hdev)
+{
+	int rc;
+	struct usb_device *usb_dev = hid_to_usb_dev(hdev);
+	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
+	char *str_buf;
+	size_t str_len = 16;
+	struct uclogic_params_frame *frame = NULL;
+
+	/*
+	 * Enable generic keyboard mode
+	 */
+	str_buf = kzalloc(str_len, GFP_KERNEL);
+	if (str_buf == NULL) {
+		rc = -ENOMEM;
+		goto cleanup;
+	}
+
+	rc = usb_string(usb_dev, 123, str_buf, str_len);
+	if (rc == -EPIPE) {
+		hid_info(hdev, "button mode setting not found\n");
+	} else if (rc < 0) {
+		hid_err(hdev, "failed to enable abstract keyboard\n");
+		goto cleanup;
+	} else if (strncmp(str_buf, "HK On", rc) != 0) {
+		hid_info(hdev, "invalid answer when requesting buttons: '%s'\n",
+			str_buf);
+	} else {
+		frame = kzalloc(sizeof(*frame), GFP_KERNEL);
+		if (frame == NULL) {
+			rc = -ENOMEM;
+			goto cleanup;
+		}
+		frame->rdesc_ptr = kzalloc(uclogic_rdesc_buttonpad_size,
+						GFP_KERNEL);
+		if (frame->rdesc_ptr == NULL) {
+			rc = -ENOMEM;
+			goto cleanup;
+		}
+		memcpy(frame->rdesc_ptr,
+			uclogic_rdesc_buttonpad_arr,
+			uclogic_rdesc_buttonpad_size);
+		frame->rdesc_size = uclogic_rdesc_buttonpad_size;
+	}
+
+	/*
+	 * Output the parameters, if requested
+	 */
+	if (pframe != NULL) {
+		*pframe = frame;
+		frame = NULL;
+	}
+
+	rc = 0;
+cleanup:
+	uclogic_params_frame_free(frame);
+	kfree(str_buf);
+	return rc;
+}
+
+/**
+ * uclogic_params_free - free resources used by struct uclogic_params
+ * (tablet interface's input parameters).
+ *
+ * @params	Input parameters to free. Can be NULL.
+ */
+void uclogic_params_free(struct uclogic_params *params)
+{
+	if (params != NULL) {
+		kfree(params->rdesc_ptr);
+		params->rdesc_ptr = NULL;
+	}
+}
+
+/**
+ * uclogic_params_probe_static() - probe a tablet interface with
+ * statically-assigned parameters.
+ *
+ * @pparams 	Location for the pointer to resulting parameters (to be
+ * 		freed with uclogic_params_free()), or for NULL if the
+ * 		parameters were not found.  Not modified in case of error.
+ * 		Can be NULL to have parameters discarded after retrieval.
+ * @hdev	The HID device of the tablet interface to initialize and
+ * 		possibly get parameters from. Cannot be NULL.
+ */
+static int uclogic_params_probe_static(struct uclogic_params **pparams,
+			 		struct hid_device *hdev)
+{
+	int rc;
+	struct usb_device *udev = hid_to_usb_dev(hdev);
+	__u8  bNumInterfaces = udev->config->desc.bNumInterfaces;
+	struct usb_interface *iface = to_usb_interface(hdev->dev.parent);
+	__u8 bInterfaceNumber = iface->cur_altsetting->desc.bInterfaceNumber;
+	/* The device's original report descriptor size */
+	unsigned dev_rdesc_size = hdev->dev_rsize;
+	/* The replacement report descriptor pointer */
+	const __u8 *rdesc_ptr = NULL;
+	/* The replacement report descriptor size */
+	unsigned int rdesc_size = 0;
+	/* The resulting parameters */
+	struct uclogic_params *params = NULL;
+
+	/* Check arguments */
+	if (hdev == NULL) {
+		rc = -EINVAL;
+		goto cleanup;
+	}
+
+	/*
+	 * Handle some models with static report descriptors
+	 */
+	switch (id->product) {
+	case USB_DEVICE_ID_UCLOGIC_TABLET_PF1209:
+		if (dev_rdesc_size == UCLOGIC_RDESC_PF1209_ORIG_SIZE) {
+			rdesc_ptr = uclogic_rdesc_pf1209_fixed_arr;
+			rdesc_size = uclogic_rdesc_pf1209_fixed_size;
+		}
+		break;
+	case USB_DEVICE_ID_UCLOGIC_TABLET_WP4030U:
+		if (dev_rdesc_size == UCLOGIC_RDESC_WPXXXXU_ORIG_SIZE) {
+			rdesc_ptr = uclogic_rdesc_wp4030u_fixed_arr;
+			rdesc_size = uclogic_rdesc_wp4030u_fixed_size;
+		}
+		break;
+	case USB_DEVICE_ID_UCLOGIC_TABLET_WP5540U:
+		if (dev_rdesc_size == UCLOGIC_RDESC_WPXXXXU_ORIG_SIZE) {
+			rdesc_ptr = uclogic_rdesc_wp5540u_fixed_arr;
+			rdesc_size = uclogic_rdesc_wp5540u_fixed_size;
+		}
+		break;
+	case USB_DEVICE_ID_UCLOGIC_TABLET_WP8060U:
+		if (dev_rdesc_size == UCLOGIC_RDESC_WPXXXXU_ORIG_SIZE) {
+			rdesc_ptr = uclogic_rdesc_wp8060u_fixed_arr;
+			rdesc_size = uclogic_rdesc_wp8060u_fixed_size;
+		}
+		break;
+	case USB_DEVICE_ID_UCLOGIC_TABLET_WP1062:
+		if (dev_rdesc_size == UCLOGIC_RDESC_WP1062_ORIG_SIZE) {
+			rdesc_ptr = uclogic_rdesc_wp1062_fixed_arr;
+			rdesc_size = uclogic_rdesc_wp1062_fixed_size;
+		}
+		break;
+	case USB_DEVICE_ID_UCLOGIC_WIRELESS_TABLET_TWHL850:
+		switch (bInterfaceNumber) {
+		case 0:
+			if (dev_rdesc_size == UCLOGIC_RDESC_TWHL850_ORIG0_SIZE) {
+				rdesc_ptr = uclogic_rdesc_twhl850_fixed0_arr;
+				rdesc_size = uclogic_rdesc_twhl850_fixed0_size;
+			}
+			break;
+		case 1:
+			if (dev_rdesc_size == UCLOGIC_RDESC_TWHL850_ORIG1_SIZE) {
+				rdesc_ptr = uclogic_rdesc_twhl850_fixed1_arr;
+				rdesc_size = uclogic_rdesc_twhl850_fixed1_size;
+			}
+			break;
+		case 2:
+			if (dev_rdesc_size == UCLOGIC_RDESC_TWHL850_ORIG2_SIZE) {
+				rdesc_ptr = uclogic_rdesc_twhl850_fixed2_arr;
+				rdesc_size = uclogic_rdesc_twhl850_fixed2_size;
+			}
+			break;
+		}
+		break;
+	case USB_DEVICE_ID_UCLOGIC_TABLET_TWHA60:
+		/*
+		 * If it is the three-interface version, which is known to
+		 * respond to initialization.
+		 */
+		if (bNumInterfaces == 3) {
+			break;
+		}
+		switch (bInterfaceNumber) {
+		case 0:
+			if (dev_RSIZE == UCLOGIC_RDESC_TWHA60_ORIG0_SIZE) {
+				rdesc_ptr = uclogic_rdesc_twha60_fixed0_arr;
+				rdesc_size = uclogic_rdesc_twha60_fixed0_size;
+			}
+			break;
+		case 1:
+			if (dev_rdesc_size == UCLOGIC_RDESC_TWHA60_ORIG1_SIZE) {
+				rdesc_ptr = uclogic_rdesc_twha60_fixed1_arr;
+				rdesc_size = uclogic_rdesc_twha60_fixed1_size;
+			}
+			break;
+		}
+		break;
+	}
+
+	/* If we got our report descriptor */
+	if (rdesc_ptr != NULL && rdesc_size != 0) {
+		/* Create parameters */
+		params = kzalloc(sizeof(*params), GFP_KERNEL);
+		if (params == NULL) {
+			rc = -ENOMEM;
+			goto cleanup;
+		}
+		params->rdesc_ptr = kmalloc(rdesc_size, GFP_KERNEL);
+		if (params->rdesc_ptr == NULL) {
+			rc = -ENOMEM;
+			goto cleanup;
+		}
+		memcpy(params->rdesc_ptr, rdesc_ptr, rdesc_size);
+		params->rdesc_size = rdesc_size;
+	}
+
+	/* Output parameters, if requested */
+	if (pparams != NULL) {
+		*pparams = params;
+		params = NULL;
+	}
+
+	rc = 0;
+
+cleanup:
+	uclogic_params_free(params);
+	return rc;
+}
+
+/**
+ * uclogic_params_probe_dynamic() - initialize a tablet interface and retrieve
+ * its parameters from the device.
+ *
+ * @pparams 	Location for the pointer to resulting parameters (to be
+ * 		freed with uclogic_params_free()), or for NULL if the
+ * 		parameters were not found.  Not modified in case of error.
+ * 		Can be NULL to have parameters discarded after retrieval.
+ * @hdev	The HID device of the tablet interface to initialize and get
+ * 		parameters from. Cannot be NULL.
+ *
+ * Return:
+ * 	Zero, if successful. A negative errno code on error.
+ */
+static int uclogic_params_probe_dynamic(struct uclogic_params **pparams,
+					struct hid_device *hdev)
+{
+	int rc;
+	bool pen_unused = false;
+	/* Pen input parameters */
+	struct uclogic_params_pen *pen = NULL;
+	/* The resulting interface parameters */
+	struct uclogic_params *params = NULL;
+
+	/* Check arguments */
+	if (hdev == NULL) {
+		rc = -EINVAL;
+		goto cleanup;
+	}
+
+	switch (id->product) {
+	case USB_DEVICE_ID_UCLOGIC_TABLET_TWHA60:
+		/* If it is the pen interface */
+		if (bInterfaceNumber == 0) {
+			rc = uclogic_params_pen_probe(&pen, hdev);
+			if (rc != 0) {
+				hid_err(hdev, "pen probing failed: %d\n", rc);
+				goto cleanup;
+			}
+			rc = uclogic_probe_buttons(hdev);
+		} else {
+			/*
+			 * TODO Switch to just disabling the
+			 * interface, if possible.
+			 */
+			pen_unused = true;
+		}
+		break;
+	case USB_DEVICE_ID_HUION_TABLET:
+	case USB_DEVICE_ID_YIYNOVA_TABLET:
+	case USB_DEVICE_ID_UCLOGIC_UGEE_TABLET_81:
+	case USB_DEVICE_ID_UCLOGIC_DRAWIMAGE_G3:
+	case USB_DEVICE_ID_UCLOGIC_UGEE_TABLET_45:
+	case USB_DEVICE_ID_UCLOGIC_UGEE_TABLET_47:
+		/* If this is the pen interface */
+		if (bInterfaceNumber == 0) {
+			rc = uclogic_params_pen_probe(&pen, hdev);
+			if (rc != 0) {
+				hid_err(hdev, "pen probing failed: %d\n", rc);
+				goto cleanup;
+			}
+			rc = uclogic_probe_buttons(hdev);
+		} else {
+			/*
+			 * TODO Switch to just disabling the interface,
+			 * if possible.
+			 */
+			pen_unused = true;
+		}
+		break;
+	case USB_DEVICE_ID_UGTIZER_TABLET_GP0610:
+	case USB_DEVICE_ID_UGEE_XPPEN_TABLET_G540:
+		/* If this is the pen interface */
+		if (bInterfaceNumber == 1) {
+			rc = uclogic_params_pen_v1_probe(&pen, hdev);
+			if (rc != 0) {
+				hid_err(hdev, "pen probing failed: %d\n", rc);
+				goto cleanup;
+			}
+		} else {
+			/*
+			 * TODO Switch to just disabling the interface,
+			 * if possible.
+			 */
+			pen_unused = true;
+		}
+		break;
+	case USB_DEVICE_ID_UGEE_TABLET_EX07S:
+		/* If this is the pen interface */
+		if (bInterfaceNumber == 1) {
+			rc = uclogic_params_pen_v1_probe(&pen, hdev);
+			if (rc != 0) {
+				hid_err(hdev, "pen probing failed: %d\n", rc);
+				goto cleanup;
+			}
+		} else {
+			/* Ignore unused interface #0 */
+			return -ENODEV;
+		}
+		break;
+	case USB_DEVICE_ID_UCLOGIC_TABLET_WP5540U:
+		/* If this is the pen interface of WP5540U v2 */
+		if (hdev->dev_rsize == UCLOGIC_RDESC_WP5540U_V2_ORIG_SIZE &&
+		    bInterfaceNumber == 0) {
+			rc = uclogic_params_pen_v1_probe(&pen, hdev);
+			if (rc != 0) {
+				hid_err(hdev, "pen probing failed: %d\n", rc);
+				goto cleanup;
+			}
+		}
+		break;
+	}
+
+	/*
+	 * Create parameters
+	 */
+	params = kzalloc(sizeof(*params), GFP_KERNEL);
+	if (params == NULL) {
+		rc = -ENOMEM;
+		goto cleanup;
+	}
+
+	params->pen_unused = pen_unused;
+	if (!params->pen_unused) {
+		params->pen_report_id = pen.report_id;
+		params->pen_report_inrange_inverted = true;
+		params->pen_report_fragmented_hires =
+				pen.report_fragmented_hires;
+	}
+
+	/* Output parameters, if requested */
+	if (pparams != NULL) {
+		*pparams = params;
+		params = NULL;
+	}
+
+	rc = 0;
+
+cleanup:
+	uclogic_params_pen_free(pen);
+	uclogic_params_free(params);
+	return rc;
+}
+
+/**
+ * uclogic_params_probe() - initialize a tablet interface and discover its
+ * parameters.
+ *
+ * @pparams 	Location for the pointer to resulting parameters (to be
+ * 		freed with uclogic_params_free()), or for NULL if the
+ * 		parameters were not found.  Not modified in case of error.
+ * 		Can be NULL to have parameters discarded after retrieval.
+ * @hdev	The HID device of the tablet interface to initialize and get
+ * 		parameters from. Cannot be NULL.
+ *
+ * Return:
+ * 	Zero, if successful. A negative errno code on error.
+ */
+int uclogic_params_probe(struct uclogic_params *params,
+			 struct hid_device *hdev)
+{
+	int rc;
+	/* The resulting parameters */
+	struct uclogic_params *params = NULL;
+
+	/* Check arguments */
+	if (hdev == NULL) {
+		return -EINVAL;
+	}
+
+	/* Try to probe static parameters */
+	rc = uclogic_params_probe_static(&params, hdev);
+	/* If not found */
+	if (rc == 0 && &params == NULL) {
+		/* Try to probe dynamic parameters */
+		rc = uclogic_params_probe_dynamic(&params, hdev);
+	}
+
+	/* Output the parameters if succeeded, and asked to */
+	if (rc == 0 && pparams != NULL) {
+		*pparams = params;
+		params = NULL;
+	}
+
+	uclogic_params_free(params);
+	return rc;
+}

--- a/hid-uclogic-params.c
+++ b/hid-uclogic-params.c
@@ -680,10 +680,10 @@ cleanup:
  * 			NULL to have parameters discarded after creation.
  * @hdev:		The HID device of the tablet interface create the
  * 			parameters for. Cannot be NULL.
- * @orig_desc_size	Expected size of the original report descriptor to
+ * @orig_desc_size:	Expected size of the original report descriptor to
  * 			be replaced.
- * @desc_ptr		Pointer to the replacement report descriptor.
- * @desc_size		Size of the replacement report descriptor.
+ * @desc_ptr:		Pointer to the replacement report descriptor.
+ * @desc_size:		Size of the replacement report descriptor.
  *
  * Return:
  * 	Zero, if successful. -EINVAL if an invalid argument was passed.

--- a/hid-uclogic-params.c
+++ b/hid-uclogic-params.c
@@ -718,12 +718,20 @@ static int uclogic_params_with_opt_desc(struct uclogic_params **pparams,
 
 	/* Replace report descriptor, if it matches */
 	if (hdev->dev_rsize == orig_desc_size) {
+		hid_dbg(hdev, "device report descriptor matches "
+				"the expected size, replacing\n");
 		params->desc_ptr = kmemdup(desc_ptr, desc_size, GFP_KERNEL);
 		if (params->desc_ptr == NULL) {
 			rc = -ENOMEM;
 			goto cleanup;
 		}
 		params->desc_size = desc_size;
+	} else {
+		hid_dbg(hdev,
+			"device report descriptor doesn't match "
+			"the expected size (%u != %u), preserving\n",
+			hdev->dev_rsize, orig_desc_size);
+
 	}
 
 	/* Output parameters, if requested */

--- a/hid-uclogic-params.c
+++ b/hid-uclogic-params.c
@@ -225,7 +225,6 @@ output:
 	}
 
 	rc = 0;
-
 cleanup:
 	uclogic_params_pen_free(pen);
 	kfree(desc_ptr);
@@ -387,7 +386,6 @@ output:
 	}
 
 	rc = 0;
-
 cleanup:
 	uclogic_params_pen_free(pen);
 	kfree(desc_ptr);

--- a/hid-uclogic-params.c
+++ b/hid-uclogic-params.c
@@ -518,7 +518,7 @@ static int uclogic_params_frame_buttonpad_v1_probe(
 				&frame,
 				uclogic_rdesc_buttonpad_v1_arr,
 				uclogic_rdesc_buttonpad_v1_size);
-		if (rc < 0) {
+		if (rc != 0) {
 			goto cleanup;
 		}
 	}

--- a/hid-uclogic-params.c
+++ b/hid-uclogic-params.c
@@ -269,8 +269,8 @@ static int uclogic_params_pen_v2_probe(struct uclogic_params_pen **ppen,
 	int rc;
 	/* Buffer for (part of) the string descriptor */
 	__u8 *buf = NULL;
-	/* Minimum descriptor length required, maximum seen so far is 18 */
-	const int len = 12;
+	/* Descriptor length required */
+	const int len = 18;
 	s32 resolution;
 	/* Pen report descriptor template parameters */
 	s32 rdesc_params[UCLOGIC_RDESC_PEN_PH_ID_NUM];

--- a/hid-uclogic-params.c
+++ b/hid-uclogic-params.c
@@ -686,12 +686,12 @@ static int uclogic_params_probe_static(struct uclogic_params **pparams,
 		}
 		params->pen_unused = pen_unused;
 		if (rdesc_ptr != NULL) {
-			params->rdesc_ptr = kmalloc(rdesc_size, GFP_KERNEL);
+			params->rdesc_ptr =
+				kmemdup(rdesc_ptr, rdesc_size, GFP_KERNEL);
 			if (params->rdesc_ptr == NULL) {
 				rc = -ENOMEM;
 				goto cleanup;
 			}
-			memcpy(params->rdesc_ptr, rdesc_ptr, rdesc_size);
 			params->rdesc_size = rdesc_size;
 		}
 	}

--- a/hid-uclogic-params.h
+++ b/hid-uclogic-params.h
@@ -19,28 +19,27 @@
 #include <linux/hid.h>
 
 /* Types of pen in-range reporting */
-enum uclogic_params_pen_report_inrange {
+enum uclogic_params_pen_inrange {
 	/* Normal reports: zero - out of proximity, one - in proximity */
-	UCLOGIC_PARAMS_PEN_REPORT_INRANGE_NORMAL,
+	UCLOGIC_PARAMS_PEN_INRANGE_NORMAL,
 	/* Inverted reports: zero - in proximity, one - out of proximity */
-	UCLOGIC_PARAMS_PEN_REPORT_INRANGE_INVERTED,
+	UCLOGIC_PARAMS_PEN_INRANGE_INVERTED,
 	/* No reports */
-	UCLOGIC_PARAMS_PEN_REPORT_INRANGE_NONE,
+	UCLOGIC_PARAMS_PEN_INRANGE_NONE,
 };
 
-/* Tablet interface parameters */
-/* TODO Consider stripping "report" from names */
+/* Tablet interface report parameters */
 struct uclogic_params {
 	/*
 	 * Pointer to replacement report descriptor allocated with kmalloc,
 	 * or NULL if no replacement is needed.
 	 */
-	__u8 *rdesc_ptr;
+	__u8 *desc_ptr;
 	/*
 	 * Size of the replacement report descriptor.
-	 * Only valid, if rdesc_ptr is not NULL.
+	 * Only valid, if desc_ptr is not NULL.
 	 */
-	unsigned int rdesc_size;
+	unsigned int desc_size;
 	/*
 	 * True, if pen usage in report descriptor is present, but unused.
 	 */
@@ -49,30 +48,30 @@ struct uclogic_params {
 	 * Pen report ID, if pen reports should be tweaked, zero if not.
 	 * Only valid if pen_unused is false.
 	 */
-	unsigned pen_report_id;
+	unsigned pen_id;
 	/*
 	 * Type of pen in-range reporting.
-	 * Only valid if pen_report_id is not zero.
+	 * Only valid if pen_id is not zero.
 	 */
-	enum uclogic_params_pen_report_inrange pen_report_inrange;
+	enum uclogic_params_pen_inrange pen_inrange;
 	/*
 	 * True, if pen reports include fragmented high resolution coords,
 	 * with high-order X and then Y bytes following the pressure field
-	 * Only valid if pen_report_id is not zero.
+	 * Only valid if pen_id is not zero.
 	 */
-	bool pen_report_fragmented_hires;
+	bool pen_fragmented_hires;
 	/*
 	 * Bitmask matching frame controls "sub-report" flag in the second
 	 * byte of the pen report, or zero if it's not expected.
-	 * Only valid if pen_report_id is valid and not zero.
+	 * Only valid if pen_id is valid and not zero.
 	 */
-	__u8 pen_report_frame_flag;
+	__u8 pen_frame_flag;
 	/*
 	 * Frame controls report ID. Used as the virtual frame report ID, for
 	 * frame button reports extracted from pen reports, if
-	 * pen_report_frame_flag is valid and not zero.
+	 * pen_frame_flag is valid and not zero.
 	 */
-	unsigned pen_report_frame_report_id;
+	unsigned pen_frame_id;
 };
 
 /* Initialize a tablet interface and discover its parameters */

--- a/hid-uclogic-params.h
+++ b/hid-uclogic-params.h
@@ -68,10 +68,11 @@ struct uclogic_params {
 	 */
 	__u8 pen_report_frame_flag;
 	/*
-	 * ID of the frame controls report, if there is one, and not more than
-	 * one. Otherwise zero.
+	 * Frame controls report ID. Used as the virtual frame report ID, for
+	 * frame button reports extracted from pen reports, if
+	 * pen_report_frame_flag is valid and not zero.
 	 */
-	unsigned frame_report_id;
+	unsigned pen_report_frame_report_id;
 };
 
 /* Initialize a tablet interface and discover its parameters */

--- a/hid-uclogic-params.h
+++ b/hid-uclogic-params.h
@@ -21,7 +21,7 @@
 /* Types of pen in-range reporting */
 enum uclogic_params_pen_inrange {
 	/* Normal reports: zero - out of proximity, one - in proximity */
-	UCLOGIC_PARAMS_PEN_INRANGE_NORMAL,
+	UCLOGIC_PARAMS_PEN_INRANGE_NORMAL = 0,
 	/* Inverted reports: zero - in proximity, one - out of proximity */
 	UCLOGIC_PARAMS_PEN_INRANGE_INVERTED,
 	/* No reports */

--- a/hid-uclogic-params.h
+++ b/hid-uclogic-params.h
@@ -61,7 +61,7 @@ struct uclogic_params {
 	 * byte of the pen report, or zero if it's not expected.
 	 * Only valid if pen_report_id is not zero.
 	 */
-	bool pen_report_frame_flag;
+	__u8 pen_report_frame_flag;
 	/*
 	 * True, if pen reports include fragmented high resolution coords,
 	 * with high-order X and then Y bytes following the pressure field

--- a/hid-uclogic-params.h
+++ b/hid-uclogic-params.h
@@ -28,7 +28,13 @@ enum uclogic_params_pen_inrange {
 	UCLOGIC_PARAMS_PEN_INRANGE_NONE,
 };
 
-/* Tablet interface report parameters */
+/*
+ * Tablet interface report parameters.
+ * Must use declarative (descriptive) language, not imperative, to simplify
+ * understanding and maintain consistency.
+ * When filled with zeros represents a "noop" configuration - passes all
+ * reports unchanged and lets the generic HID driver handle everything.
+ */
 struct uclogic_params {
 	/*
 	 * Pointer to replacement report descriptor allocated with kmalloc,
@@ -41,7 +47,7 @@ struct uclogic_params {
 	 */
 	unsigned int desc_size;
 	/*
-	 * True, if pen usage in report descriptor is present, but unused.
+	 * True, if pen usage in report descriptor is unused, if present.
 	 */
 	bool pen_unused;
 	/*
@@ -51,13 +57,13 @@ struct uclogic_params {
 	unsigned pen_id;
 	/*
 	 * Type of pen in-range reporting.
-	 * Only valid if pen_id is not zero.
+	 * Only valid if pen_id is valid and not zero.
 	 */
 	enum uclogic_params_pen_inrange pen_inrange;
 	/*
 	 * True, if pen reports include fragmented high resolution coords,
 	 * with high-order X and then Y bytes following the pressure field
-	 * Only valid if pen_id is not zero.
+	 * Only valid if pen_id is valid and not zero.
 	 */
 	bool pen_fragmented_hires;
 	/*

--- a/hid-uclogic-params.h
+++ b/hid-uclogic-params.h
@@ -78,6 +78,12 @@ struct uclogic_params {
 /* Initialize a tablet interface and discover its parameters */
 extern int uclogic_params_probe(struct uclogic_params **pparams,
 				struct hid_device *hdev);
+
+/* Dump tablet interface parameters with hid_dbg */
+extern void uclogic_params_dump(const struct uclogic_params *params,
+				const struct hid_device *hdev,
+				const char *prefix);
+
 /* Free resources used by tablet interface's parameters */
 extern void uclogic_params_free(struct uclogic_params *params);
 

--- a/hid-uclogic-params.h
+++ b/hid-uclogic-params.h
@@ -68,10 +68,11 @@ struct uclogic_params {
 	 */
 	bool pen_report_fragmented_hires;
 	/*
-	 * Virtual report ID to use for frame control "sub-reports" extracted
-	 * from the pen reports.
+	 * Frame controls report ID. Used as a virtual frame report ID, for
+	 * frame button reports extracted from pen reports, if
+	 * pen_report_frame_flag is valid and not zero.
 	 */
-	unsigned pen_frame_report_id;
+	unsigned frame_report_id;
 };
 
 /* Initialize a tablet interface and discover its parameters */

--- a/hid-uclogic-params.h
+++ b/hid-uclogic-params.h
@@ -43,7 +43,6 @@ struct uclogic_params {
 	unsigned int rdesc_size;
 	/*
 	 * True, if pen usage in report descriptor is present, but unused.
-	 * TODO Switch to just disabling unused interfaces, if possible.
 	 */
 	bool pen_unused;
 	/*
@@ -69,10 +68,10 @@ struct uclogic_params {
 	 */
 	bool pen_report_fragmented_hires;
 	/*
-	 * Virtual report ID to use for frame controls "sub-reports" extracted
+	 * Virtual report ID to use for frame control "sub-reports" extracted
 	 * from the pen reports.
 	 */
-	unsigned frame_virtual_report_id;
+	unsigned pen_frame_report_id;
 };
 
 /* Initialize a tablet interface and discover its parameters */

--- a/hid-uclogic-params.h
+++ b/hid-uclogic-params.h
@@ -28,6 +28,10 @@ enum uclogic_params_pen_inrange {
 	UCLOGIC_PARAMS_PEN_INRANGE_NONE,
 };
 
+/* Convert a pen in-range reporting type to a string */
+extern const char *uclogic_params_pen_inrange_to_str(
+			enum uclogic_params_pen_inrange inrange);
+
 /*
  * Tablet interface report parameters.
  * Must use declarative (descriptive) language, not imperative, to simplify
@@ -84,10 +88,27 @@ struct uclogic_params {
 extern int uclogic_params_probe(struct uclogic_params **pparams,
 				struct hid_device *hdev);
 
-/* Dump tablet interface parameters with hid_dbg */
-extern void uclogic_params_dump(const struct uclogic_params *params,
-				const struct hid_device *hdev,
-				const char *prefix);
+/* Tablet interface parameters *printf format string */
+#define UCLOGIC_PARAMS_FMT_STR \
+		".desc_ptr = %p\n"              \
+		".desc_size = %u\n"             \
+		".pen_unused = %s\n"            \
+		".pen_id = %u\n"                \
+		".pen_inrange = %s\n"           \
+		".pen_fragmented_hires = %s\n"  \
+		".pen_frame_flag = 0x%02x\n"    \
+		".pen_frame_id = %u\n"
+
+/* Tablet interface parameters *printf format arguments */
+#define UCLOGIC_PARAMS_FMT_ARGS(_params) \
+		(_params)->desc_ptr,                                        \
+		(_params)->desc_size,                                       \
+		((_params)->pen_unused ? "true" : "false"),                 \
+		(_params)->pen_id,                                          \
+		uclogic_params_pen_inrange_to_str((_params)->pen_inrange),  \
+		((_params)->pen_fragmented_hires ? "true" : "false"),       \
+		(_params)->pen_frame_flag,                                  \
+		(_params)->pen_frame_id
 
 /* Free resources used by tablet interface's parameters */
 extern void uclogic_params_free(struct uclogic_params *params);

--- a/hid-uclogic-params.h
+++ b/hid-uclogic-params.h
@@ -46,7 +46,7 @@ struct uclogic_params {
 	 */
 	bool pen_unused;
 	/*
-	 * Pen report ID, if pen reports should be tweaked, zero if not
+	 * Pen report ID, if pen reports should be tweaked, zero if not.
 	 * Only valid if pen_unused is false.
 	 */
 	unsigned pen_report_id;
@@ -56,21 +56,20 @@ struct uclogic_params {
 	 */
 	enum uclogic_params_pen_report_inrange pen_report_inrange;
 	/*
-	 * Bitmask matching frame controls "sub-report" flag in the second
-	 * byte of the pen report, or zero if it's not expected.
-	 * Only valid if pen_report_id is not zero.
-	 */
-	__u8 pen_report_frame_flag;
-	/*
 	 * True, if pen reports include fragmented high resolution coords,
 	 * with high-order X and then Y bytes following the pressure field
 	 * Only valid if pen_report_id is not zero.
 	 */
 	bool pen_report_fragmented_hires;
 	/*
-	 * Frame controls report ID. Used as a virtual frame report ID, for
-	 * frame button reports extracted from pen reports, if
-	 * pen_report_frame_flag is valid and not zero.
+	 * Bitmask matching frame controls "sub-report" flag in the second
+	 * byte of the pen report, or zero if it's not expected.
+	 * Only valid if pen_report_id is valid and not zero.
+	 */
+	__u8 pen_report_frame_flag;
+	/*
+	 * ID of the frame controls report, if there is one, and not more than
+	 * one. Otherwise zero.
 	 */
 	unsigned frame_report_id;
 };

--- a/hid-uclogic-params.h
+++ b/hid-uclogic-params.h
@@ -1,0 +1,75 @@
+/*
+ *  HID driver for UC-Logic devices not fully compliant with HID standard
+ *  - tablet initialization and parameter retrieval
+ *
+ *  Copyright (c) 2018 Nikolai Kondrashov
+ */
+
+/*
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ */
+
+#ifndef _HID_UCLOGIC_PARAMS_H
+#define _HID_UCLOGIC_PARAMS_H
+
+#include <linux/usb.h>
+
+/* Tablet interface parameters */
+struct uclogic_params {
+	/*
+	 * Pointer to replacement report descriptor allocated with kmalloc,
+	 * or NULL if no replacement is needed.
+	 */
+	__u8 *rdesc_ptr;
+	/*
+	 * Size of the replacement report descriptor,
+	 * or zero if no replacement is needed.
+	 */
+	unsigned int rdesc_size;
+	/*
+	 * True, if pen usage in report descriptor is present, but unused.
+	 * TODO Switch to just disabling unused interfaces, if possible.
+	 */
+	bool pen_unused;
+	/*
+	 * Pen report ID, if pen reports should be tweaked, zero if not
+	 * Only valid if pen_unused is false.
+	 */
+	unsigned pen_report_id;
+	/*
+	 * True, if pen in-range bit is inverted in reports.
+	 * Only valid if pen_report_id is not zero.
+	 */
+	bool pen_report_inrange_inverted;
+	/*
+	 * True if pen doesn't report in-range (proximity) event.
+	 * Only valid if pen_report_id is not zero.
+	 */
+	bool pen_report_inrange_none;
+	/*
+	 * Bitmask matching frame controls "sub-report" flag in the second
+	 * byte of the pen report, or zero if it's not expected.
+	 * Only valid if pen_report_id is not zero.
+	 */
+	bool pen_report_frame_flag;
+	/*
+	 * True, if pen reports include fragmented high resolution coords,
+	 * with high-order X and then Y bytes following the pressure field
+	 * Only valid if pen_report_id is not zero.
+	 */
+	bool pen_report_fragmented_hires;
+	/*
+	 * Virtual report ID to use for frame controls "sub-reports" extracted
+	 * from the pen reports.
+	 */
+	unsigned frame_virtual_report_id;
+};
+
+extern int uclogic_params_probe(struct uclogic_params *pparams,
+				struct hid_device *hdev);
+extern void uclogic_params_cleanup(struct uclogic_params *params);
+
+#endif /* _HID_UCLOGIC_PARAMS_H */

--- a/hid-uclogic-params.h
+++ b/hid-uclogic-params.h
@@ -16,8 +16,20 @@
 #define _HID_UCLOGIC_PARAMS_H
 
 #include <linux/usb.h>
+#include <linux/hid.h>
+
+/* Types of pen in-range reporting */
+enum uclogic_params_pen_report_inrange {
+	/* Normal reports: zero - out of proximity, one - in proximity */
+	UCLOGIC_PARAMS_PEN_REPORT_INRANGE_NORMAL,
+	/* Inverted reports: zero - in proximity, one - out of proximity */
+	UCLOGIC_PARAMS_PEN_REPORT_INRANGE_INVERTED,
+	/* No reports */
+	UCLOGIC_PARAMS_PEN_REPORT_INRANGE_NONE,
+};
 
 /* Tablet interface parameters */
+/* TODO Consider stripping "report" from names */
 struct uclogic_params {
 	/*
 	 * Pointer to replacement report descriptor allocated with kmalloc,
@@ -25,8 +37,8 @@ struct uclogic_params {
 	 */
 	__u8 *rdesc_ptr;
 	/*
-	 * Size of the replacement report descriptor,
-	 * or zero if no replacement is needed.
+	 * Size of the replacement report descriptor.
+	 * Only valid, if rdesc_ptr is not NULL.
 	 */
 	unsigned int rdesc_size;
 	/*
@@ -40,15 +52,10 @@ struct uclogic_params {
 	 */
 	unsigned pen_report_id;
 	/*
-	 * True, if pen in-range bit is inverted in reports.
+	 * Type of pen in-range reporting.
 	 * Only valid if pen_report_id is not zero.
 	 */
-	bool pen_report_inrange_inverted;
-	/*
-	 * True if pen doesn't report in-range (proximity) event.
-	 * Only valid if pen_report_id is not zero.
-	 */
-	bool pen_report_inrange_none;
+	enum uclogic_params_pen_report_inrange pen_report_inrange;
 	/*
 	 * Bitmask matching frame controls "sub-report" flag in the second
 	 * byte of the pen report, or zero if it's not expected.
@@ -68,8 +75,10 @@ struct uclogic_params {
 	unsigned frame_virtual_report_id;
 };
 
-extern int uclogic_params_probe(struct uclogic_params *pparams,
+/* Initialize a tablet interface and discover its parameters */
+extern int uclogic_params_probe(struct uclogic_params **pparams,
 				struct hid_device *hdev);
-extern void uclogic_params_cleanup(struct uclogic_params *params);
+/* Free resources used by tablet interface's parameters */
+extern void uclogic_params_free(struct uclogic_params *params);
 
 #endif /* _HID_UCLOGIC_PARAMS_H */

--- a/hid-uclogic-rdesc.c
+++ b/hid-uclogic-rdesc.c
@@ -733,43 +733,57 @@ const __u8 uclogic_rdesc_ugee_ex07_template_arr[] = {
 const size_t uclogic_rdesc_ugee_ex07_template_size =
 			sizeof(uclogic_rdesc_ugee_ex07_template_arr);
 
-/* Fixed report descriptor template for basic button frame controls */
-const __u8 uclogic_rdesc_buttonpad_template_arr[] = {
-	0x05, 0x01,		/*  Usage Page (Desktop),               */
-	0x09, 0x07,		/*  Usage (Keypad),                     */
-	0xA1, 0x01,		/*  Collection (Application),           */
-	0x85, 0xF7,		/*      Report ID (247),                */
-	0x14,			/*      Logical Minimum (0),            */
-	0x25, 0x01,		/*      Logical Maximum (1),            */
-	0x75, 0x01,		/*      Report Size (1),                */
-	0x05, 0x0D,		/*      Usage Page (Digitizer),         */
-	0x09, 0x39,		/*      Usage (Tablet Function Keys),   */
-	0xA0,			/*      Collection (Physical),          */
-	0x05, 0x09,		/*          Usage Page (Button),        */
-	0x95, 0x18,		/*          Report Count (24),          */
-	0x81, 0x01,		/*          Input (Constant),           */
-	0x19, 0x01,		/*          Usage Minimum (01h),        */
-	0x29, 0x0A,		/*          Usage Maximum (0Ah),        */
-	0x95, 0x0A,		/*          Report Count (10),          */
-	0x81, 0x02,		/*          Input (Variable),           */
-	0xC0,			/*      End Collection,                 */
-	0x05, 0x01,		/*      Usage Page (Desktop),           */
-	0x09, 0x05,		/*      Usage (Gamepad),                */
-	0xA0,			/*      Collection (Physical),          */
-	0x05, 0x09,		/*          Usage Page (Button),        */
-	0x19, 0x01,		/*          Usage Minimum (01h),        */
-	0x29, 0x02,		/*          Usage Maximum (02h),        */
-	0x95, 0x02,		/*          Report Count (2),           */
-	0x81, 0x02,		/*          Input (Variable),           */
-	0x97, UCLOGIC_RDESC_BUTTONPAD_PH(PADDING),
-				/*          Report Count (PLACEHOLDER), */
-	0x81, 0x01,		/*          Input (Constant),           */
-	0xC0,			/*      End Collection,                 */
-	0xC0			/*  End Collection                      */
-};
+/**
+ * Expand to the contents of a generic buttonpad report descriptor.
+ *
+ * @_padding	Padding from the end of button bits at bit 44, until
+ * 		the end of the report, in bits.
+ */
+#define UCLOGIC_RDESC_BUTTONPAD_BYTES(_padding) \
+	0x05, 0x01,	/*  Usage Page (Desktop),               */ \
+	0x09, 0x07,	/*  Usage (Keypad),                     */ \
+	0xA1, 0x01,	/*  Collection (Application),           */ \
+	0x85, 0xF7,	/*      Report ID (247),                */ \
+	0x14,		/*      Logical Minimum (0),            */ \
+	0x25, 0x01,	/*      Logical Maximum (1),            */ \
+	0x75, 0x01,	/*      Report Size (1),                */ \
+	0x05, 0x0D,	/*      Usage Page (Digitizer),         */ \
+	0x09, 0x39,	/*      Usage (Tablet Function Keys),   */ \
+	0xA0,		/*      Collection (Physical),          */ \
+	0x05, 0x09,	/*          Usage Page (Button),        */ \
+	0x95, 0x18,	/*          Report Count (24),          */ \
+	0x81, 0x01,	/*          Input (Constant),           */ \
+	0x19, 0x01,	/*          Usage Minimum (01h),        */ \
+	0x29, 0x0A,	/*          Usage Maximum (0Ah),        */ \
+	0x95, 0x0A,	/*          Report Count (10),          */ \
+	0x81, 0x02,	/*          Input (Variable),           */ \
+	0xC0,		/*      End Collection,                 */ \
+	0x05, 0x01,	/*      Usage Page (Desktop),           */ \
+	0x09, 0x05,	/*      Usage (Gamepad),                */ \
+	0xA0,		/*      Collection (Physical),          */ \
+	0x05, 0x09,	/*          Usage Page (Button),        */ \
+	0x19, 0x01,	/*          Usage Minimum (01h),        */ \
+	0x29, 0x02,	/*          Usage Maximum (02h),        */ \
+	0x95, 0x02,	/*          Report Count (2),           */ \
+	0x81, 0x02,	/*          Input (Variable),           */ \
+	0x95, _padding,	/*          Report Count (_padding),    */ \
+	0x81, 0x01,	/*          Input (Constant),           */ \
+	0xC0,		/*      End Collection,                 */ \
+	0xC0		/*  End Collection                      */
 
-const size_t uclogic_rdesc_buttonpad_template_size =
-			sizeof(uclogic_rdesc_buttonpad_template_arr);
+/* Fixed report descriptor for (tweaked) v1 buttonpad reports */
+const __u8 uclogic_rdesc_buttonpad_v1_arr[] = {
+	UCLOGIC_RDESC_BUTTONPAD_BYTES(20)
+};
+const size_t uclogic_rdesc_buttonpad_v1_size =
+			sizeof(uclogic_rdesc_buttonpad_v1_arr);
+
+/* Fixed report descriptor for (tweaked) v2 buttonpad reports */
+const __u8 uclogic_rdesc_buttonpad_v2_arr[] = {
+	UCLOGIC_RDESC_BUTTONPAD_BYTES(52)
+};
+const size_t uclogic_rdesc_buttonpad_v2_size =
+			sizeof(uclogic_rdesc_buttonpad_v2_arr);
 
 /**
  * uclogic_rdesc_template_apply() - apply report descriptor parameters to a

--- a/hid-uclogic-rdesc.c
+++ b/hid-uclogic-rdesc.c
@@ -647,36 +647,44 @@ const size_t uclogic_rdesc_pen_v2_template_size =
  * 		the end of the report, in bits.
  */
 #define UCLOGIC_RDESC_BUTTONPAD_BYTES(_padding) \
-	0x05, 0x01,	/*  Usage Page (Desktop),               */ \
-	0x09, 0x07,	/*  Usage (Keypad),                     */ \
-	0xA1, 0x01,	/*  Collection (Application),           */ \
-	0x85, 0xF7,	/*      Report ID (247),                */ \
-	0x14,		/*      Logical Minimum (0),            */ \
-	0x25, 0x01,	/*      Logical Maximum (1),            */ \
-	0x75, 0x01,	/*      Report Size (1),                */ \
-	0x05, 0x0D,	/*      Usage Page (Digitizer),         */ \
-	0x09, 0x39,	/*      Usage (Tablet Function Keys),   */ \
-	0xA0,		/*      Collection (Physical),          */ \
-	0x05, 0x09,	/*          Usage Page (Button),        */ \
-	0x95, 0x18,	/*          Report Count (24),          */ \
-	0x81, 0x01,	/*          Input (Constant),           */ \
-	0x19, 0x01,	/*          Usage Minimum (01h),        */ \
-	0x29, 0x0A,	/*          Usage Maximum (0Ah),        */ \
-	0x95, 0x0A,	/*          Report Count (10),          */ \
-	0x81, 0x02,	/*          Input (Variable),           */ \
-	0xC0,		/*      End Collection,                 */ \
-	0x05, 0x01,	/*      Usage Page (Desktop),           */ \
-	0x09, 0x05,	/*      Usage (Gamepad),                */ \
-	0xA0,		/*      Collection (Physical),          */ \
-	0x05, 0x09,	/*          Usage Page (Button),        */ \
-	0x19, 0x01,	/*          Usage Minimum (01h),        */ \
-	0x29, 0x02,	/*          Usage Maximum (02h),        */ \
-	0x95, 0x02,	/*          Report Count (2),           */ \
-	0x81, 0x02,	/*          Input (Variable),           */ \
-	0x95, _padding,	/*          Report Count (_padding),    */ \
-	0x81, 0x01,	/*          Input (Constant),           */ \
-	0xC0,		/*      End Collection,                 */ \
-	0xC0		/*  End Collection                      */
+	0x05, 0x01,     /*  Usage Page (Desktop),               */ \
+	0x09, 0x07,     /*  Usage (Keypad),                     */ \
+	0xA1, 0x01,     /*  Collection (Application),           */ \
+	0x85, 0xF7,     /*      Report ID (247),                */ \
+	0x14,           /*      Logical Minimum (0),            */ \
+	0x25, 0x01,     /*      Logical Maximum (1),            */ \
+	0x75, 0x01,     /*      Report Size (1),                */ \
+	0x05, 0x0D,     /*      Usage Page (Digitizer),         */ \
+	0x09, 0x39,     /*      Usage (Tablet Function Keys),   */ \
+	0xA0,           /*      Collection (Physical),          */ \
+	0x09, 0x44,     /*          Usage (Barrel Switch),      */ \
+	0x95, 0x01,     /*          Report Count (1),           */ \
+	0x81, 0x02,     /*          Input (Variable),           */ \
+	0x05, 0x01,     /*          Usage Page (Desktop),       */ \
+	0x09, 0x30,     /*          Usage (X),                  */ \
+	0x09, 0x31,     /*          Usage (Y),                  */ \
+	0x95, 0x02,     /*          Report Count (2),           */ \
+	0x81, 0x02,     /*          Input (Variable),           */ \
+	0x95, 0x15,     /*          Report Count (21),          */ \
+	0x81, 0x01,     /*          Input (Constant),           */ \
+	0x05, 0x09,     /*          Usage Page (Button),        */ \
+	0x19, 0x01,     /*          Usage Minimum (01h),        */ \
+	0x29, 0x0A,     /*          Usage Maximum (0Ah),        */ \
+	0x95, 0x0A,     /*          Report Count (10),          */ \
+	0x81, 0x02,     /*          Input (Variable),           */ \
+	0xC0,           /*      End Collection,                 */ \
+	0x05, 0x01,     /*      Usage Page (Desktop),           */ \
+	0x09, 0x05,     /*      Usage (Gamepad),                */ \
+	0xA0,           /*      Collection (Physical),          */ \
+	0x05, 0x09,     /*          Usage Page (Button),        */ \
+	0x19, 0x01,     /*          Usage Minimum (01h),        */ \
+	0x29, 0x02,     /*          Usage Maximum (02h),        */ \
+	0x95, 0x02,     /*          Report Count (2),           */ \
+	0x81, 0x02,     /*          Input (Variable),           */ \
+	0x95, _padding, /*          Report Count (_padding),    */ \
+	0x81, 0x01,     /*          Input (Constant),           */ \
+	0xC0,           /*      End Collection,                 */ \
+	0xC0            /*  End Collection                      */
 
 /* Fixed report descriptor for (tweaked) v1 buttonpad reports */
 const __u8 uclogic_rdesc_buttonpad_v1_arr[] = {

--- a/hid-uclogic-rdesc.c
+++ b/hid-uclogic-rdesc.c
@@ -529,8 +529,8 @@ __u8 uclogic_rdesc_twha60_fixed1_arr[] = {
 const size_t uclogic_rdesc_twha60_fixed1_size =
 			sizeof(uclogic_rdesc_twha60_fixed1_arr);
 
-/* Fixed report descriptor template for pen reports */
-const __u8 uclogic_rdesc_pen_template_arr[] = {
+/* Fixed report descriptor template for (tweaked) v1 pen reports */
+const __u8 uclogic_rdesc_pen_v1_template_arr[] = {
 	0x05, 0x0D,             /*  Usage Page (Digitizer),                 */
 	0x09, 0x02,             /*  Usage (Pen),                            */
 	0xA1, 0x01,             /*  Collection (Application),               */
@@ -573,16 +573,71 @@ const __u8 uclogic_rdesc_pen_template_arr[] = {
 	0x81, 0x02,             /*          Input (Variable),               */
 	0xB4,                   /*          Pop,                            */
 	0x09, 0x30,             /*          Usage (Tip Pressure),           */
-	0x27,
-	UCLOGIC_RDESC_PEN_PH(PRESSURE_LM),
+	0x27, UCLOGIC_RDESC_PEN_PH(PRESSURE_LM),
 				/*          Logical Maximum (PLACEHOLDER),  */
 	0x81, 0x02,             /*          Input (Variable),               */
 	0xC0,                   /*      End Collection,                     */
 	0xC0                    /*  End Collection                          */
 };
 
-const size_t uclogic_rdesc_pen_template_size =
-			sizeof(uclogic_rdesc_pen_template_arr);
+const size_t uclogic_rdesc_pen_v1_template_size =
+			sizeof(uclogic_rdesc_pen_v1_template_arr);
+
+/* Fixed report descriptor template for (tweaked) v2 pen reports */
+const __u8 uclogic_rdesc_pen_v2_template_arr[] = {
+	0x05, 0x0D,             /*  Usage Page (Digitizer),                 */
+	0x09, 0x02,             /*  Usage (Pen),                            */
+	0xA1, 0x01,             /*  Collection (Application),               */
+	0x85, 0x08,             /*      Report ID (8),                      */
+	0x09, 0x20,             /*      Usage (Stylus),                     */
+	0xA0,                   /*      Collection (Physical),              */
+	0x14,                   /*          Logical Minimum (0),            */
+	0x25, 0x01,             /*          Logical Maximum (1),            */
+	0x75, 0x01,             /*          Report Size (1),                */
+	0x09, 0x42,             /*          Usage (Tip Switch),             */
+	0x09, 0x44,             /*          Usage (Barrel Switch),          */
+	0x09, 0x46,             /*          Usage (Tablet Pick),            */
+	0x95, 0x03,             /*          Report Count (3),               */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0x95, 0x03,             /*          Report Count (3),               */
+	0x81, 0x03,             /*          Input (Constant, Variable),     */
+	0x09, 0x32,             /*          Usage (In Range),               */
+	0x95, 0x01,             /*          Report Count (1),               */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0x95, 0x01,             /*          Report Count (1),               */
+	0x81, 0x03,             /*          Input (Constant, Variable),     */
+	0x95, 0x01,             /*          Report Count (1),               */
+	0xA4,                   /*          Push,                           */
+	0x05, 0x01,             /*          Usage Page (Desktop),           */
+	0x65, 0x13,             /*          Unit (Inch),                    */
+	0x55, 0xFD,             /*          Unit Exponent (-3),             */
+	0x75, 0x18,             /*          Report Size (24),               */
+	0x34,                   /*          Physical Minimum (0),           */
+	0x09, 0x30,             /*          Usage (X),                      */
+	0x27, UCLOGIC_RDESC_PEN_PH(X_LM),
+				/*          Logical Maximum (PLACEHOLDER),  */
+	0x47, UCLOGIC_RDESC_PEN_PH(X_PM),
+				/*          Physical Maximum (PLACEHOLDER), */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0x09, 0x31,             /*          Usage (Y),                      */
+	0x27, UCLOGIC_RDESC_PEN_PH(Y_LM),
+				/*          Logical Maximum (PLACEHOLDER),  */
+	0x47, UCLOGIC_RDESC_PEN_PH(Y_PM),
+				/*          Physical Maximum (PLACEHOLDER), */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0xB4,                   /*          Pop,                            */
+	0x09, 0x30,             /*          Usage (Tip Pressure),           */
+	0x75, 0x10,             /*          Report Size (16),               */
+	0x27, UCLOGIC_RDESC_PEN_PH(PRESSURE_LM),
+				/*          Logical Maximum (PLACEHOLDER),  */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0x81, 0x03,             /*          Input (Constant, Variable),     */
+	0xC0,                   /*      End Collection,                     */
+	0xC0                    /*  End Collection                          */
+};
+
+const size_t uclogic_rdesc_pen_v2_template_size =
+			sizeof(uclogic_rdesc_pen_v2_template_arr);
 
 /* Fixed report descriptor template for Ugee EX07 */
 const __u8 uclogic_rdesc_ugee_ex07_template_arr[] = {

--- a/hid-uclogic-rdesc.c
+++ b/hid-uclogic-rdesc.c
@@ -640,99 +640,6 @@ const __u8 uclogic_rdesc_pen_v2_template_arr[] = {
 const size_t uclogic_rdesc_pen_v2_template_size =
 			sizeof(uclogic_rdesc_pen_v2_template_arr);
 
-/* Fixed report descriptor template for Ugee EX07 */
-const __u8 uclogic_rdesc_ugee_ex07_template_arr[] = {
-	0x05, 0x0D,             /*  Usage Page (Digitizer),                 */
-	0x09, 0x02,             /*  Usage (Pen),                            */
-	0xA1, 0x01,             /*  Collection (Application),               */
-	0x85, 0x07,             /*      Report ID (7),                      */
-	0x09, 0x20,             /*      Usage (Stylus),                     */
-	0xA0,                   /*      Collection (Physical),              */
-	0x14,                   /*          Logical Minimum (0),            */
-	0x25, 0x01,             /*          Logical Maximum (1),            */
-	0x75, 0x01,             /*          Report Size (1),                */
-	0x09, 0x42,             /*          Usage (Tip Switch),             */
-	0x09, 0x44,             /*          Usage (Barrel Switch),          */
-	0x09, 0x46,             /*          Usage (Tablet Pick),            */
-	0x95, 0x03,             /*          Report Count (3),               */
-	0x81, 0x02,             /*          Input (Variable),               */
-	0x95, 0x03,             /*          Report Count (3),               */
-	0x81, 0x03,             /*          Input (Constant, Variable),     */
-	0x09, 0x32,             /*          Usage (In Range),               */
-	0x95, 0x01,             /*          Report Count (1),               */
-	0x81, 0x02,             /*          Input (Variable),               */
-	0x95, 0x01,             /*          Report Count (1),               */
-	0x81, 0x03,             /*          Input (Constant, Variable),     */
-	0x75, 0x10,             /*          Report Size (16),               */
-	0x95, 0x01,             /*          Report Count (1),               */
-	0xA4,                   /*          Push,                           */
-	0x05, 0x01,             /*          Usage Page (Desktop),           */
-	0x65, 0x13,             /*          Unit (Inch),                    */
-	0x55, 0xFD,             /*          Unit Exponent (-3),             */
-	0x34,                   /*          Physical Minimum (0),           */
-	0x09, 0x30,             /*          Usage (X),                      */
-	0x27, UCLOGIC_RDESC_PEN_PH(X_LM),
-				/*          Logical Maximum (PLACEHOLDER),  */
-	0x47, UCLOGIC_RDESC_PEN_PH(X_PM),
-				/*          Physical Maximum (PLACEHOLDER), */
-	0x81, 0x02,             /*          Input (Variable),               */
-	0x09, 0x31,             /*          Usage (Y),                      */
-	0x27, UCLOGIC_RDESC_PEN_PH(Y_LM),
-				/*          Logical Maximum (PLACEHOLDER),  */
-	0x47, UCLOGIC_RDESC_PEN_PH(Y_PM),
-				/*          Physical Maximum (PLACEHOLDER), */
-	0x81, 0x02,             /*          Input (Variable),               */
-	0xB4,                   /*          Pop,                            */
-	0x09, 0x30,             /*          Usage (Tip Pressure),           */
-	0x27,
-	UCLOGIC_RDESC_PEN_PH(PRESSURE_LM),
-				/*          Logical Maximum (PLACEHOLDER),  */
-	0x81, 0x02,             /*          Input (Variable),               */
-	0xC0,                   /*      End Collection,                     */
-	0xC0,                   /*  End Collection                          */
-	0x05, 0x01,             /*  Usage Page (Desktop),                   */
-	0x09, 0x07,             /*  Usage (Keypad),                         */
-	0xA1, 0x01,             /*  Collection (Application),               */
-	0x85, 0x06,             /*      Report ID (6),                      */
-	0x05, 0x0D,             /*      Usage Page (Digitizer),             */
-	0x09, 0x39,             /*      Usage (Tablet Function Keys),       */
-	0xA0,                   /*      Collection (Physical),              */
-	0x05, 0x09,             /*          Usage Page (Button),            */
-	0x75, 0x01,             /*          Report Size (1),                */
-	0x19, 0x03,             /*          Usage Minimum (03h),            */
-	0x29, 0x06,             /*          Usage Maximum (06h),            */
-	0x95, 0x04,             /*          Report Count (4),               */
-	0x81, 0x02,             /*          Input (Variable),               */
-	0x95, 0x1A,             /*          Report Count (26),              */
-	0x81, 0x03,             /*          Input (Constant, Variable),     */
-	0x19, 0x01,             /*          Usage Minimum (01h),            */
-	0x29, 0x02,             /*          Usage Maximum (02h),            */
-	0x95, 0x02,             /*          Report Count (2),               */
-	0x81, 0x02,             /*          Input (Variable),               */
-	0x05, 0x0D,             /*          Usage Page (Digitizer),         */
-	0x09, 0x20,             /*          Usage (Stylus),                 */
-	0x14,                   /*          Logical Minimum (0),            */
-	0x25, 0x01,             /*          Logical Maximum (1),            */
-	0x09, 0x44,             /*          Usage (Barrel Switch),          */
-	0x95, 0x01,             /*          Report Count (1),               */
-	0x81, 0x02,             /*          Input (Variable),               */
-	0x05, 0x01,             /*          Usage Page (Desktop),           */
-	0x09, 0x30,             /*          Usage (X),                      */
-	0x09, 0x31,             /*          Usage (Y),                      */
-	0x95, 0x02,             /*          Report Count (2),               */
-	0x81, 0x02,             /*          Input (Variable),               */
-	0x05, 0x0D,             /*          Usage Page (Digitizer),         */
-	0x09, 0xFF,             /*          Usage (FFh),                    */
-	0x75, 0x05,             /*          Report Size (5),                */
-	0x95, 0x01,             /*          Report Count (1),               */
-	0x81, 0x02,             /*          Input (Variable),               */
-	0xC0,                   /*      End Collection,                     */
-	0xC0                    /*  End Collection                          */
-};
-
-const size_t uclogic_rdesc_ugee_ex07_template_size =
-			sizeof(uclogic_rdesc_ugee_ex07_template_arr);
-
 /**
  * Expand to the contents of a generic buttonpad report descriptor.
  *
@@ -784,6 +691,34 @@ const __u8 uclogic_rdesc_buttonpad_v2_arr[] = {
 };
 const size_t uclogic_rdesc_buttonpad_v2_size =
 			sizeof(uclogic_rdesc_buttonpad_v2_arr);
+
+/* Fixed report descriptor for Ugee EX07 buttonpad */
+const __u8 uclogic_rdesc_ugee_ex07_buttonpad_arr[] = {
+	0x05, 0x01,             /*  Usage Page (Desktop),                   */
+	0x09, 0x07,             /*  Usage (Keypad),                         */
+	0xA1, 0x01,             /*  Collection (Application),               */
+	0x85, 0x06,             /*      Report ID (6),                      */
+	0x05, 0x0D,             /*      Usage Page (Digitizer),             */
+	0x09, 0x39,             /*      Usage (Tablet Function Keys),       */
+	0xA0,                   /*      Collection (Physical),              */
+	0x05, 0x09,             /*          Usage Page (Button),            */
+	0x75, 0x01,             /*          Report Size (1),                */
+	0x19, 0x03,             /*          Usage Minimum (03h),            */
+	0x29, 0x06,             /*          Usage Maximum (06h),            */
+	0x95, 0x04,             /*          Report Count (4),               */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0x95, 0x1A,             /*          Report Count (26),              */
+	0x81, 0x03,             /*          Input (Constant, Variable),     */
+	0x19, 0x01,             /*          Usage Minimum (01h),            */
+	0x29, 0x02,             /*          Usage Maximum (02h),            */
+	0x95, 0x02,             /*          Report Count (2),               */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0xC0,                   /*      End Collection,                     */
+	0xC0                    /*  End Collection                          */
+};
+
+const size_t uclogic_rdesc_ugee_ex07_buttonpad_size =
+			sizeof(uclogic_rdesc_ugee_ex07_buttonpad_arr);
 
 /**
  * uclogic_rdesc_template_apply() - apply report descriptor parameters to a

--- a/hid-uclogic-rdesc.c
+++ b/hid-uclogic-rdesc.c
@@ -14,6 +14,7 @@
  */
 
 #include "hid-uclogic-rdesc.h"
+#include <linux/slab.h>
 #include <asm/unaligned.h>
 
 /* Fixed WP4030U report descriptor */

--- a/hid-uclogic-rdesc.c
+++ b/hid-uclogic-rdesc.c
@@ -528,8 +528,8 @@ __u8 uclogic_rdesc_twha60_fixed1_arr[] = {
 const size_t uclogic_rdesc_twha60_fixed1_size =
 			sizeof(uclogic_rdesc_twha60_fixed1_arr);
 
-/* Fixed report descriptor template */
-const __u8 uclogic_rdesc_tablet_template_arr[] = {
+/* Fixed report descriptor template for pen reports */
+const __u8 uclogic_rdesc_pen_template_arr[] = {
 	0x05, 0x0D,             /*  Usage Page (Digitizer),                 */
 	0x09, 0x02,             /*  Usage (Pen),                            */
 	0xA1, 0x01,             /*  Collection (Application),               */
@@ -559,29 +559,29 @@ const __u8 uclogic_rdesc_tablet_template_arr[] = {
 	0x55, 0xFD,             /*          Unit Exponent (-3),             */
 	0x34,                   /*          Physical Minimum (0),           */
 	0x09, 0x30,             /*          Usage (X),                      */
-	0x27, UCLOGIC_RDESC_PH(X_LM),
+	0x27, UCLOGIC_RDESC_PEN_PH(X_LM),
 				/*          Logical Maximum (PLACEHOLDER),  */
-	0x47, UCLOGIC_RDESC_PH(X_PM),
+	0x47, UCLOGIC_RDESC_PEN_PH(X_PM),
 				/*          Physical Maximum (PLACEHOLDER), */
 	0x81, 0x02,             /*          Input (Variable),               */
 	0x09, 0x31,             /*          Usage (Y),                      */
-	0x27, UCLOGIC_RDESC_PH(Y_LM),
+	0x27, UCLOGIC_RDESC_PEN_PH(Y_LM),
 				/*          Logical Maximum (PLACEHOLDER),  */
-	0x47, UCLOGIC_RDESC_PH(Y_PM),
+	0x47, UCLOGIC_RDESC_PEN_PH(Y_PM),
 				/*          Physical Maximum (PLACEHOLDER), */
 	0x81, 0x02,             /*          Input (Variable),               */
 	0xB4,                   /*          Pop,                            */
 	0x09, 0x30,             /*          Usage (Tip Pressure),           */
 	0x27,
-	UCLOGIC_RDESC_PH(PRESSURE_LM),
+	UCLOGIC_RDESC_PEN_PH(PRESSURE_LM),
 				/*          Logical Maximum (PLACEHOLDER),  */
 	0x81, 0x02,             /*          Input (Variable),               */
 	0xC0,                   /*      End Collection,                     */
 	0xC0                    /*  End Collection                          */
 };
 
-const size_t uclogic_rdesc_tablet_template_size =
-			sizeof(uclogic_rdesc_tablet_template_arr);
+const size_t uclogic_rdesc_pen_template_size =
+			sizeof(uclogic_rdesc_pen_template_arr);
 
 /* Fixed report descriptor template for Ugee EX07 */
 const __u8 uclogic_rdesc_ugee_ex07_template_arr[] = {
@@ -614,21 +614,21 @@ const __u8 uclogic_rdesc_ugee_ex07_template_arr[] = {
 	0x55, 0xFD,             /*          Unit Exponent (-3),             */
 	0x34,                   /*          Physical Minimum (0),           */
 	0x09, 0x30,             /*          Usage (X),                      */
-	0x27, UCLOGIC_RDESC_PH(X_LM),
+	0x27, UCLOGIC_RDESC_PEN_PH(X_LM),
 				/*          Logical Maximum (PLACEHOLDER),  */
-	0x47, UCLOGIC_RDESC_PH(X_PM),
+	0x47, UCLOGIC_RDESC_PEN_PH(X_PM),
 				/*          Physical Maximum (PLACEHOLDER), */
 	0x81, 0x02,             /*          Input (Variable),               */
 	0x09, 0x31,             /*          Usage (Y),                      */
-	0x27, UCLOGIC_RDESC_PH(Y_LM),
+	0x27, UCLOGIC_RDESC_PEN_PH(Y_LM),
 				/*          Logical Maximum (PLACEHOLDER),  */
-	0x47, UCLOGIC_RDESC_PH(Y_PM),
+	0x47, UCLOGIC_RDESC_PEN_PH(Y_PM),
 				/*          Physical Maximum (PLACEHOLDER), */
 	0x81, 0x02,             /*          Input (Variable),               */
 	0xB4,                   /*          Pop,                            */
 	0x09, 0x30,             /*          Usage (Tip Pressure),           */
 	0x27,
-	UCLOGIC_RDESC_PH(PRESSURE_LM),
+	UCLOGIC_RDESC_PEN_PH(PRESSURE_LM),
 				/*          Logical Maximum (PLACEHOLDER),  */
 	0x81, 0x02,             /*          Input (Variable),               */
 	0xC0,                   /*      End Collection,                     */

--- a/hid-uclogic-rdesc.c
+++ b/hid-uclogic-rdesc.c
@@ -797,12 +797,10 @@ __u8 *uclogic_rdesc_template_apply(const __u8 *template_ptr,
 	__u8 *p;
 	s32 v;
 
-	rdesc_ptr = kmalloc(template_size, GFP_KERNEL);
+	rdesc_ptr = kmemdup(template_ptr, template_size, GFP_KERNEL);
 	if (rdesc_ptr == NULL) {
 		return NULL;
 	}
-
-	memcpy(rdesc_ptr, template_ptr, template_size);
 
 	for (p = rdesc_ptr; p + sizeof(head) < rdesc_ptr + template_size;) {
 		if (memcmp(p, head, sizeof(head)) == 0 &&

--- a/hid-uclogic-rdesc.c
+++ b/hid-uclogic-rdesc.c
@@ -733,46 +733,43 @@ const __u8 uclogic_rdesc_ugee_ex07_template_arr[] = {
 const size_t uclogic_rdesc_ugee_ex07_template_size =
 			sizeof(uclogic_rdesc_ugee_ex07_template_arr);
 
-/* Fixed virtual pad report descriptor */
-const __u8 uclogic_rdesc_buttonpad_arr[] = {
-	0x05, 0x01,             /*  Usage Page (Desktop),                   */
-	0x09, 0x07,             /*  Usage (Keypad),                         */
-	0xA1, 0x01,             /*  Collection (Application),               */
-	0x85, 0xF7,             /*      Report ID (247),                    */
-	0x05, 0x0D,             /*      Usage Page (Digitizers),            */
-	0x09, 0x39,             /*      Usage (Tablet Function Keys),       */
-	0xA0,                   /*      Collection (Physical),              */
-	0x05, 0x09,             /*          Usage Page (Button),            */
-	0x75, 0x01,             /*          Report Size (1),                */
-	0x95, 0x18,             /*          Report Count (24),              */
-	0x81, 0x03,             /*          Input (Constant, Variable),     */
-	0x19, 0x01,             /*          Usage Minimum (01h),            */
-	0x29, 0x08,             /*          Usage Maximum (08h),            */
-	0x95, 0x08,             /*          Report Count (8),               */
-	0x81, 0x02,             /*          Input (Variable),               */
-	0x05, 0x0D,             /*          Usage Page (Digitizers),        */
-	0x09, 0x20,             /*          Usage (Stylus),                 */
-	0x14,                   /*          Logical Minimum (0),            */
-	0x25, 0x01,             /*          Logical Maximum (1),            */
-	0x09, 0x44,             /*          Usage (Barrel Switch),          */
-	0x95, 0x01,             /*          Report Count (1),               */
-	0x81, 0x02,             /*          Input (Data,Var,Abs),           */
-	0x05, 0x01,             /*          Usage Page (Generic Desktop),   */
-	0x09, 0x30,             /*          Usage (X),                      */
-	0x09, 0x31,             /*          Usage (Y),                      */
-	0x95, 0x02,             /*          Report Count (2),               */
-	0x81, 0x02,             /*          Input (Data,Var,Abs),           */
-	0x05, 0x0D,             /*          Usage Page (Digitizers),        */
-	0x09, 0xFF,             /*          Usage (Vendor Usage 0xff),      */
-	0x75, 0x05,             /*          Report Size (5),                */
-	0x95, 0x01,             /*          Report Count (1),               */
-	0x81, 0x02,             /*          Input (Data,Var,Abs),           */
-	0xC0,                   /*      End Collection                      */
-	0xC0                    /*  End Collection                          */
+/* Fixed report descriptor template for basic button frame controls */
+const __u8 uclogic_rdesc_buttonpad_template_arr[] = {
+	0x05, 0x01,		/*  Usage Page (Desktop),               */
+	0x09, 0x07,		/*  Usage (Keypad),                     */
+	0xA1, 0x01,		/*  Collection (Application),           */
+	0x85, 0xF7,		/*      Report ID (247),                */
+	0x14,			/*      Logical Minimum (0),            */
+	0x25, 0x01,		/*      Logical Maximum (1),            */
+	0x75, 0x01,		/*      Report Size (1),                */
+	0x05, 0x0D,		/*      Usage Page (Digitizer),         */
+	0x09, 0x39,		/*      Usage (Tablet Function Keys),   */
+	0xA0,			/*      Collection (Physical),          */
+	0x05, 0x09,		/*          Usage Page (Button),        */
+	0x95, 0x18,		/*          Report Count (24),          */
+	0x81, 0x01,		/*          Input (Constant),           */
+	0x19, 0x01,		/*          Usage Minimum (01h),        */
+	0x29, 0x0A,		/*          Usage Maximum (0Ah),        */
+	0x95, 0x0A,		/*          Report Count (10),          */
+	0x81, 0x02,		/*          Input (Variable),           */
+	0xC0,			/*      End Collection,                 */
+	0x05, 0x01,		/*      Usage Page (Desktop),           */
+	0x09, 0x05,		/*      Usage (Gamepad),                */
+	0xA0,			/*      Collection (Physical),          */
+	0x05, 0x09,		/*          Usage Page (Button),        */
+	0x19, 0x01,		/*          Usage Minimum (01h),        */
+	0x29, 0x02,		/*          Usage Maximum (02h),        */
+	0x95, 0x02,		/*          Report Count (2),           */
+	0x81, 0x02,		/*          Input (Variable),           */
+	0x97, UCLOGIC_RDESC_BUTTONPAD_PH(PADDING),
+				/*          Report Count (PLACEHOLDER), */
+	0x81, 0x01,		/*          Input (Constant),           */
+	0xC0,			/*      End Collection,                 */
+	0xC0			/*  End Collection                      */
 };
 
-const size_t uclogic_rdesc_buttonpad_size =
-			sizeof(uclogic_rdesc_buttonpad_arr);
+const size_t uclogic_rdesc_buttonpad_template_size =
+			sizeof(uclogic_rdesc_buttonpad_template_arr);
 
 /**
  * uclogic_rdesc_template_apply() - apply report descriptor parameters to a

--- a/hid-uclogic-rdesc.h
+++ b/hid-uclogic-rdesc.h
@@ -82,6 +82,9 @@ extern const size_t uclogic_rdesc_twha60_fixed1_size;
 /* Report descriptor template placeholder head */
 #define UCLOGIC_RDESC_PH_HEAD	0xFE, 0xED, 0x1D
 
+/* Report descriptor template placeholder */
+#define UCLOGIC_RDESC_PH(_ID) UCLOGIC_RDESC_PH_HEAD, UCLOGIC_RDESC_PH_ID_##_ID
+
 /* Report descriptor template placeholder IDs */
 enum uclogic_rdesc_ph_id {
 	UCLOGIC_RDESC_PH_ID_X_LM,
@@ -91,9 +94,6 @@ enum uclogic_rdesc_ph_id {
 	UCLOGIC_RDESC_PH_ID_PRESSURE_LM,
 	UCLOGIC_RDESC_PH_ID_NUM
 };
-
-/* Report descriptor template placeholder */
-#define UCLOGIC_RDESC_PH(_ID) UCLOGIC_RDESC_PH_HEAD, UCLOGIC_RDESC_PH_ID_##_ID
 
 /* Fixed report descriptor template */
 extern const __u8 uclogic_rdesc_tablet_template_arr[];

--- a/hid-uclogic-rdesc.h
+++ b/hid-uclogic-rdesc.h
@@ -130,8 +130,8 @@ extern const size_t uclogic_rdesc_buttonpad_v2_size;
 /* Report ID for tweaked v2 buttonpad reports */
 #define UCLOGIC_RDESC_BUTTONPAD_V2_ID 0xf7
 
-/* Fixed report descriptor template for Ugee EX07 */
-extern const __u8 uclogic_rdesc_ugee_ex07_template_arr[];
-extern const size_t uclogic_rdesc_ugee_ex07_template_size;
+/* Fixed report descriptor for Ugee EX07 buttonpad */
+extern const __u8 uclogic_rdesc_ugee_ex07_buttonpad_arr[];
+extern const size_t uclogic_rdesc_ugee_ex07_buttonpad_size;
 
 #endif /* _HID_UCLOGIC_RDESC_H */

--- a/hid-uclogic-rdesc.h
+++ b/hid-uclogic-rdesc.h
@@ -116,22 +116,19 @@ extern const size_t uclogic_rdesc_pen_v1_template_size;
 extern const __u8 uclogic_rdesc_pen_v2_template_arr[];
 extern const size_t uclogic_rdesc_pen_v2_template_size;
 
-/* Button pad report descriptor template placeholder IDs */
-enum uclogic_rdesc_buttonpad_ph_id {
-	UCLOGIC_RDESC_BUTTONPAD_PH_ID_PADDING,
-	UCLOGIC_RDESC_BUTTONPAD_PH_ID_NUM
-};
+/* Fixed report descriptor for (tweaked) v1 buttonpad reports */
+extern const __u8 uclogic_rdesc_buttonpad_v1_arr[];
+extern const size_t uclogic_rdesc_buttonpad_v1_size;
 
-/* Button pad report descriptor template placeholder */
-#define UCLOGIC_RDESC_BUTTONPAD_PH(_ID) \
-	UCLOGIC_RDESC_PH_HEAD, UCLOGIC_RDESC_BUTTONPAD_PH_ID_##_ID
+/* Report ID for tweaked v1 buttonpad reports */
+#define UCLOGIC_RDESC_BUTTONPAD_V1_ID 0xf7
 
-/* Fixed report descriptor template for basic button frame controls */
-extern const __u8 uclogic_rdesc_buttonpad_template_arr[];
-extern const size_t uclogic_rdesc_buttonpad_template_size;
+/* Fixed report descriptor for (tweaked) v2 buttonpad reports */
+extern const __u8 uclogic_rdesc_buttonpad_v2_arr[];
+extern const size_t uclogic_rdesc_buttonpad_v2_size;
 
-/* Report ID for button pad reports */
-#define UCLOGIC_RDESC_BUTTONPAD_ID 0xf7
+/* Report ID for tweaked v2 buttonpad reports */
+#define UCLOGIC_RDESC_BUTTONPAD_V2_ID 0xf7
 
 /* Fixed report descriptor template for Ugee EX07 */
 extern const __u8 uclogic_rdesc_ugee_ex07_template_arr[];

--- a/hid-uclogic-rdesc.h
+++ b/hid-uclogic-rdesc.h
@@ -102,9 +102,19 @@ enum uclogic_rdesc_pen_ph_id {
 #define UCLOGIC_RDESC_PEN_PH(_ID) \
 	UCLOGIC_RDESC_PH_HEAD, UCLOGIC_RDESC_PEN_PH_ID_##_ID
 
-/* Fixed report descriptor template for pen reports */
-extern const __u8 uclogic_rdesc_pen_template_arr[];
-extern const size_t uclogic_rdesc_pen_template_size;
+/* Report ID for v1 pen reports */
+#define UCLOGIC_RDESC_PEN_V1_ID	0x07
+
+/* Fixed report descriptor template for (tweaked) v1 pen reports */
+extern const __u8 uclogic_rdesc_pen_v1_template_arr[];
+extern const size_t uclogic_rdesc_pen_v1_template_size;
+
+/* Report ID for v2 pen reports */
+#define UCLOGIC_RDESC_PEN_V2_ID	0x08
+
+/* Fixed report descriptor template for (tweaked) v2 pen reports */
+extern const __u8 uclogic_rdesc_pen_v2_template_arr[];
+extern const size_t uclogic_rdesc_pen_v2_template_size;
 
 /* Fixed report descriptor template for Ugee EX07 */
 extern const __u8 uclogic_rdesc_ugee_ex07_template_arr[];

--- a/hid-uclogic-rdesc.h
+++ b/hid-uclogic-rdesc.h
@@ -116,12 +116,25 @@ extern const size_t uclogic_rdesc_pen_v1_template_size;
 extern const __u8 uclogic_rdesc_pen_v2_template_arr[];
 extern const size_t uclogic_rdesc_pen_v2_template_size;
 
+/* Button pad report descriptor template placeholder IDs */
+enum uclogic_rdesc_buttonpad_ph_id {
+	UCLOGIC_RDESC_BUTTONPAD_PH_ID_PADDING,
+	UCLOGIC_RDESC_BUTTONPAD_PH_ID_NUM
+};
+
+/* Button pad report descriptor template placeholder */
+#define UCLOGIC_RDESC_BUTTONPAD_PH(_ID) \
+	UCLOGIC_RDESC_PH_HEAD, UCLOGIC_RDESC_BUTTONPAD_PH_ID_##_ID
+
+/* Fixed report descriptor template for basic button frame controls */
+extern const __u8 uclogic_rdesc_buttonpad_template_arr[];
+extern const size_t uclogic_rdesc_buttonpad_template_size;
+
+/* Report ID for button pad reports */
+#define UCLOGIC_RDESC_BUTTONPAD_ID 0xf7
+
 /* Fixed report descriptor template for Ugee EX07 */
 extern const __u8 uclogic_rdesc_ugee_ex07_template_arr[];
 extern const size_t uclogic_rdesc_ugee_ex07_template_size;
-
-/* Fixed virtual pad report descriptor */
-extern const __u8 uclogic_rdesc_buttonpad_arr[];
-extern const size_t uclogic_rdesc_buttonpad_size;
 
 #endif /* _HID_UCLOGIC_RDESC_H */

--- a/hid-uclogic-rdesc.h
+++ b/hid-uclogic-rdesc.h
@@ -82,22 +82,23 @@ extern const size_t uclogic_rdesc_twha60_fixed1_size;
 /* Report descriptor template placeholder head */
 #define UCLOGIC_RDESC_PH_HEAD	0xFE, 0xED, 0x1D
 
-/* Report descriptor template placeholder */
-#define UCLOGIC_RDESC_PH(_ID) UCLOGIC_RDESC_PH_HEAD, UCLOGIC_RDESC_PH_ID_##_ID
-
-/* Report descriptor template placeholder IDs */
-enum uclogic_rdesc_ph_id {
-	UCLOGIC_RDESC_PH_ID_X_LM,
-	UCLOGIC_RDESC_PH_ID_X_PM,
-	UCLOGIC_RDESC_PH_ID_Y_LM,
-	UCLOGIC_RDESC_PH_ID_Y_PM,
-	UCLOGIC_RDESC_PH_ID_PRESSURE_LM,
-	UCLOGIC_RDESC_PH_ID_NUM
+/* Pen report descriptor template placeholder IDs */
+enum uclogic_rdesc_pen_ph_id {
+	UCLOGIC_RDESC_PEN_PH_ID_X_LM,
+	UCLOGIC_RDESC_PEN_PH_ID_X_PM,
+	UCLOGIC_RDESC_PEN_PH_ID_Y_LM,
+	UCLOGIC_RDESC_PEN_PH_ID_Y_PM,
+	UCLOGIC_RDESC_PEN_PH_ID_PRESSURE_LM,
+	UCLOGIC_RDESC_PEN_PH_ID_NUM
 };
 
-/* Fixed report descriptor template */
-extern const __u8 uclogic_rdesc_tablet_template_arr[];
-extern const size_t uclogic_rdesc_tablet_template_size;
+/* Report descriptor pen template placeholder */
+#define UCLOGIC_RDESC_PEN_PH(_ID) \
+	UCLOGIC_RDESC_PH_HEAD, UCLOGIC_RDESC_PEN_PH_ID_##_ID
+
+/* Fixed report descriptor template for pen reports */
+extern const __u8 uclogic_rdesc_pen_template_arr[];
+extern const size_t uclogic_rdesc_pen_template_size;
 
 /* Fixed report descriptor template for Ugee EX07 */
 extern const __u8 uclogic_rdesc_ugee_ex07_template_arr[];

--- a/hid-uclogic-rdesc.h
+++ b/hid-uclogic-rdesc.h
@@ -82,6 +82,12 @@ extern const size_t uclogic_rdesc_twha60_fixed1_size;
 /* Report descriptor template placeholder head */
 #define UCLOGIC_RDESC_PH_HEAD	0xFE, 0xED, 0x1D
 
+/* Apply report descriptor parameters to a report descriptor template */
+extern __u8 *uclogic_rdesc_template_apply(const __u8 *template_ptr,
+					  size_t template_size,
+					  const s32 *param_list,
+					  size_t param_num);
+
 /* Pen report descriptor template placeholder IDs */
 enum uclogic_rdesc_pen_ph_id {
 	UCLOGIC_RDESC_PEN_PH_ID_X_LM,


### PR DESCRIPTION
This is a work-in-progress branch, which nevertheless should support the new
Huion tablets adequately.
I'll probably merge this after I get feedback from the users and fix it up,
but the history will need to be redone for contributing to the upstream
kernel, separately.

If you want to have configurable shortcuts assigned to the buttons on your
tablet's frame, you will need to use the Wacom X.org driver. Install the Wacom
driver package, and put the following into
`/etc/X11/xorg.conf.d/50-tablet.conf`:

    Section "InputClass"
            Identifier "UC-Logic on Wacom"
            MatchUSBID "<USB_VID_PID>"
            MatchDevicePath "/dev/input/event*"
            Driver "wacom"
    EndSection

Where `<USB_VID_PID>` is a VID:PID number pair from `lsusb` output. E.g. if
you have a Huion tablet that will likely be `256c:006e` and the file will look
like this:

    Section "InputClass"
            Identifier "UC-Logic on Wacom"
            MatchUSBID "256c:006e"
            MatchDevicePath "/dev/input/event*"
            Driver "wacom"
    EndSection

Then logout and login again (or simply restart the machine), and your tablet
should be handled by the Wacom driver. To verify run `xsetwacom --list
devices`. You should see your tablet in the output. You will have two devices
("stylus" and "pad") there if you have buttons on the frame.

Then you can assign shortcuts to the buttons on the "pad" device using the
`xsetwacom` tool, as described in its manual.
