### PR TITLE
add support for Parblo Mast10

### DIFF
--- a/hid-uclogic-rdesc.c
+++ b/hid-uclogic-rdesc.c
@@ -827,6 +827,57 @@ const __u8 uclogic_rdesc_xppen_deco01_frame_arr[] = {
 const size_t uclogic_rdesc_xppen_deco01_frame_size =
 			sizeof(uclogic_rdesc_xppen_deco01_frame_arr);
 
+/* Fixed Mast10 report descriptor, interface 0 (stylus) */
+__u8 uclogic_rdesc_mast10_fixed0_arr[] = {
+	0x05, 0x0D,             /*  Usage Page (Digitizer),                 */
+	0x09, 0x02,             /*  Usage (Pen),                            */
+	0xA1, 0x01,             /*  Collection (Application),               */
+	0x85, 0x07,             /*      Report ID (7),                      */
+	0x09, 0x20,             /*      Usage (Stylus),                     */
+	0xA0,                   /*      Collection (Physical),              */
+	0x14,                   /*          Logical Minimum (0),            */
+	0x25, 0x01,             /*          Logical Maximum (1),            */
+	0x75, 0x01,             /*          Report Size (1),                */
+	0x09, 0x42,             /*          Usage (Tip Switch),             */
+	0x09, 0x44,             /*          Usage (Barrel Switch),          */
+	0x09, 0x46,             /*          Usage (Tablet Pick),            */
+	0x95, 0x03,             /*          Report Count (3),               */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0x95, 0x03,             /*          Report Count (3),               */
+	0x81, 0x03,             /*          Input (Constant, Variable),     */
+	0x09, 0x32,             /*          Usage (In Range),               */
+	0x95, 0x01,             /*          Report Count (1),               */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0x95, 0x01,             /*          Report Count (1),               */
+	0x81, 0x03,             /*          Input (Constant, Variable),     */
+	0x75, 0x10,             /*          Report Size (16),               */
+	0x95, 0x01,             /*          Report Count (1),               */
+	0xA4,                   /*          Push,                           */
+	0x05, 0x01,             /*          Usage Page (Desktop),           */
+	0x65, 0x13,             /*          Unit (Inch),                    */
+	0x55, 0xFD,             /*          Unit Exponent (-3),             */
+	0x34,                   /*          Physical Minimum (0),           */
+	0x09, 0x30,             /*          Usage (X),                      */
+	0x26, 0xBE, 0x54,       /*          Logical Maximum (21694),        */
+	0x46, 0x5D, 0x21,       /*          Physical Maximum (8541),        */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0x09, 0x31,             /*          Usage (Y),                      */
+	0x26, 0xF6, 0x34,       /*          Logical Maximum (13558),        */
+	0x46, 0xDA, 0x14,       /*          Physical Maximum (5338),        */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0xB4,                   /*          Pop,                            */
+	0x09, 0x30,             /*          Usage (Tip Pressure),           */
+	0x26, 0xFF, 0x07,       /*          Logical Maximum (2047),         */
+	0x81, 0x02,             /*          Input (Variable),               */
+	0x75, 0x10,             /*          Report Size (16),               */
+	0x95, 0x01,             /*          Report Count (1),               */
+	0x81, 0x03,             /*          Input (Constant, Variable),     */
+	0xC0,                   /*      End Collection,                     */
+	0xC0                    /*  End Collection                          */
+};
+const size_t uclogic_rdesc_mast10_fixed0_size =
+			sizeof(uclogic_rdesc_mast10_fixed0_arr);
+
 /**
  * uclogic_rdesc_template_apply() - apply report descriptor parameters to a
  * report descriptor template, creating a report descriptor. Copies the

--- a/hid-uclogic-rdesc.h
+++ b/hid-uclogic-rdesc.h
@@ -152,4 +152,11 @@ extern const size_t uclogic_rdesc_ugee_g5_frame_size;
 /* Least-significant bit of Ugee G5 frame rotary encoder state */
 #define UCLOGIC_RDESC_UGEE_G5_FRAME_RE_LSB 38
 
+/* Size of the original descriptors of Mast10 tablet */
+#define UCLOGIC_RDESC_MAST10_ORIG0_SIZE 192
+
+/* Fixed report descriptor for Mast10 tablet */
+extern __u8 uclogic_rdesc_mast10_fixed0_arr[];
+extern const size_t uclogic_rdesc_mast10_fixed0_size;
+
 #endif /* _HID_UCLOGIC_RDESC_H */


### PR DESCRIPTION
Addresses issue #103 
This device has the same vendor ID and device ID 5543:004d as the Yiynova tablets. I am not sure if it is sufficient to check the descriptor size to distinguish between Parblo and Yiynova.

