### PR TITLE
uclogic: Pass keyboard reports as is

### DIFF
--- a/hid-uclogic-params.c
+++ b/hid-uclogic-params.c
@@ -703,8 +703,12 @@ static int uclogic_params_huion_init(struct uclogic_params *params,
 		goto cleanup;
 	}
 
-	/* If it's not a pen interface */
-	if (bInterfaceNumber != 0) {
+	/* If it's a custom keyboard interface */
+	if (bInterfaceNumber == 1) {
+		/* Keep everything intact */
+		goto output;
+	/* Else, if it's not a pen interface */
+	} else if (bInterfaceNumber != 0) {
 		uclogic_params_init_invalid(&p);
 		goto output;
 	}

--- a/xorg.conf
+++ b/xorg.conf
@@ -8,6 +8,7 @@ Section "InputClass"
 	Identifier "Huion tablets with Wacom driver"
 	MatchUSBID "5543:006e|256c:006e|256c:006d"
 	MatchDevicePath "/dev/input/event*"
+	MatchIsKeyboard "false"
 	Driver "wacom"
 EndSection
 


### PR DESCRIPTION
Allow keyboard reports from interface #1 of Huion tablets to pass
unmodified, and stop the Wacom X.org driver from handling them.

The method for the latter is rather crude and also take the Dial reports
from the Wacom driver, but it's expected that libinput will be able to
handle them (still to be tested).

This enables Huion HS611 media and desktop keys.