### PR TITLE
Use HID_QUIRK_HIDINPUT_FORCE to fix #550

### DIFF
--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -163,6 +163,9 @@ static int uclogic_input_configured(struct hid_device *hdev,
 		case HID_GD_KEYPAD:
 			suffix = "Pad";
 			break;
+		case HID_DG_DIGITIZER:
+			suffix = "Digitizer";
+			break;
 		case HID_DG_PEN:
 			suffix = "Pen";
 			break;

--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -203,6 +203,14 @@ static int uclogic_probe(struct hid_device *hdev,
 #ifdef HID_QUIRK_NO_EMPTY_INPUT
 	hdev->quirks |= HID_QUIRK_NO_EMPTY_INPUT;
 #endif
+	/*
+	 * We must force HIDINPUT, since some devices are of class
+	 * HID_DG_DIGITIZER, which is (incorrectly?) not considered as
+	 * input by macro IS_INPUT_APPLICATION().
+	 * With this quirk all devices are forced to go through
+	 * hidinput_connect() to be configured as input devices.
+	 */
+	hdev->quirks |= HID_QUIRK_HIDINPUT_FORCE;
 
 	/* Allocate and assign driver data */
 	drvdata = devm_kzalloc(&hdev->dev, sizeof(*drvdata), GFP_KERNEL);


### PR DESCRIPTION
We must force HIDINPUT, since after ec5c16d some devices are of class `HID_DG_DIGITIZER`, which is (incorrectly?) not considered as input by macro `IS_INPUT_APPLICATION()`.

With this quirk all devices are forced to go through `hidinput_connect()` to be configured as input devices.

For instance, XP-PEN G430S was broken by ec5c16d and it works now.

I also included a second (cosmetic) patch which makes devices of class `HID_DG_DIGITIZER` to use suffix "Digitizer" in the name of the device (used for dmesg, libinput, xinput,...)