### PR TITLE
Debug raw input

### DIFF
--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -422,6 +422,32 @@ static int uclogic_raw_event_frame(
 	return 0;
 }
 
+static void dbg_raw_input(struct hid_device *hdev, u8 *data, int size)
+{
+	int pos;
+	int posb;
+	char tmp[10];
+	char binary[255];
+	char hex[255];
+
+	hid_dbg(hdev, "report hex: ");
+	strcpy(hex, "");
+	for (pos=0 ; pos < size ; pos++) {
+		u8 a = data[pos];
+		strcpy(tmp, "");
+		snprintf(tmp, sizeof(tmp), "%.2d:%02x ", pos,  a);
+		strcat(hex, tmp);
+		strcpy(binary, "");
+		for (posb = 7; posb >= 0; posb--) {
+			strcpy(tmp, "");
+			snprintf(tmp, sizeof(tmp), "%d:%d ", 7-posb, !!((a << posb) & 0x80));
+			strcat(binary, tmp);
+		}
+		hid_dbg(hdev, "%.2d %s", pos, binary);
+	}
+	hid_dbg(hdev, "%s", hex);
+}
+
 static int uclogic_raw_event(struct hid_device *hdev,
 				struct hid_report *report,
 				u8 *data, int size)
@@ -437,6 +463,8 @@ static int uclogic_raw_event(struct hid_device *hdev,
 	if (report->type != HID_INPUT_REPORT) {
 		return 0;
 	}
+
+	dbg_raw_input(hdev, data, size);
 
 	while (true) {
 		/* Tweak pen reports, if necessary */


### PR DESCRIPTION
A verbose raw output to check what bit is representing a button, ring, strip, consumer, pen, etc...

expose the info in hexadecimal format, and in binary format

Example output:

```
report hex: 
00 0:0 1:0 2:0 3:1 4:0 5:0 6:0 7:0 
01 0:0 1:0 2:0 3:0 4:0 5:1 6:1 7:1 
02 0:1 1:0 2:0 3:0 4:0 5:0 6:0 7:0 
03 0:1 1:0 2:0 3:0 4:0 5:0 6:0 7:0 
04 0:0 1:0 2:0 3:0 4:0 5:0 6:0 7:0 
05 0:0 1:0 2:0 3:0 4:0 5:0 6:0 7:0 
06 0:1 1:0 2:0 3:0 4:0 5:0 6:0 7:0 
07 0:0 1:0 2:0 3:0 4:0 5:0 6:0 7:0 
08 0:0 1:0 2:0 3:0 4:0 5:0 6:0 7:0 
09 0:0 1:0 2:0 3:0 4:0 5:0 6:0 7:0 
10 0:0 1:0 2:0 3:0 4:0 5:0 6:0 7:0 
11 0:0 1:0 2:0 3:0 4:0 5:0 6:0 7:0
00:08 01:e0 02:01 03:01 04:00 05:00 06:01 07:00 08:00 09:00 10:00 11:00
```

I understand this can be too verbose, but seems useful, so trying to report someone need it.

probably similar to usbhid-dump