### PR TITLE
report missing buttons on Huion KD100

### DIFF
--- a/hid-uclogic-rdesc.c
+++ b/hid-uclogic-rdesc.c
@@ -689,8 +689,8 @@ const size_t uclogic_rdesc_v2_pen_template_size =
 	0xA0,           /*      Collection (Physical),          */ \
 	0x05, 0x09,     /*          Usage Page (Button),        */ \
 	0x19, 0x01,     /*          Usage Minimum (01h),        */ \
-	0x29, 0x03,     /*          Usage Maximum (03h),        */ \
-	0x95, 0x03,     /*          Report Count (3),           */ \
+	0x29, 0x09,     /*          Usage Maximum (09h),        */ \
+	0x95, 0x09,     /*          Report Count (09,           */ \
 	0x81, 0x02,     /*          Input (Variable),           */ \
 	0x95, ((_size) * 8 - 45),                                  \
 			/*          Report Count (padding),     */ \
@@ -708,7 +708,7 @@ const size_t uclogic_rdesc_v1_frame_size =
 /* Fixed report descriptor for (tweaked) v2 frame button reports */
 const __u8 uclogic_rdesc_v2_frame_buttons_arr[] = {
 	UCLOGIC_RDESC_FRAME_BUTTONS_BYTES(UCLOGIC_RDESC_V2_FRAME_BUTTONS_ID,
-					  12)
+					  19)
 };
 const size_t uclogic_rdesc_v2_frame_buttons_size =
 			sizeof(uclogic_rdesc_v2_frame_buttons_arr);


### PR DESCRIPTION
Tentative PR to report missing buttons on Huion KD100

BTN_C
BTN_NORTH
BTN_WEST
BTN_Z
BTN_TL
BTN_TR

bit is correctly detected pressing the pad button:

here `BTN_C`:

```
[ 2204.507765] hid_uclogic:report_pad_btn:438: uclogic 0003:256C:006D.0004: BTN_C: 1
[ 2204.507782] hid_uclogic:report_pad_btn:438: uclogic 0003:256C:006D.0004: BTN_NORTH: 0
[ 2204.507784] hid_uclogic:report_pad_btn:438: uclogic 0003:256C:006D.0004: BTN_WEST: 0
[ 2204.507785] hid_uclogic:report_pad_btn:438: uclogic 0003:256C:006D.0004: BTN_Z: 0
[ 2204.507786] hid_uclogic:report_pad_btn:438: uclogic 0003:256C:006D.0004: BTN_TL: 0
[ 2204.507787] hid_uclogic:report_pad_btn:438: uclogic 0003:256C:006D.0004: BTN_TR: 0
```

but report is not correctly created. Any help appreciated

relates #592 