### PR TITLE
uclogic: typo FALL THROUGH

### DIFF
--- a/hid-uclogic-params.c
+++ b/hid-uclogic-params.c
@@ -1161,7 +1161,7 @@ int uclogic_params_init(struct uclogic_params *params,
 			}
 			break;
 		}
-		/* FALL THROUGH */
+		/* FALLTHROUGH */
 	case VID_PID(USB_VENDOR_ID_HUION,
 		     USB_DEVICE_ID_HUION_TABLET):
 	case VID_PID(USB_VENDOR_ID_HUION,


### PR DESCRIPTION
gcc expects /* FALLTHROUGH */
cf. https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>