### PR TITLE
Handle DKMS using slash to separate module version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,8 +110,8 @@ dkms_modules_uninstall: dkms_check
 	dkms status $(DKMS_MODULES_NAME) | \
 	    while IFS=':' read -r modules status; do \
 	        echo "$$modules" | { \
-	            IFS=', ' read -r modules_name modules_version \
-	                             kernel_version kernel_arch ignore; \
+	            IFS=',/ ' read -r modules_name modules_version \
+	                              kernel_version kernel_arch ignore; \
 	            if [ -z "$$kernel_version" ]; then \
 	                dkms remove \
 	                            "$$modules_name/$$modules_version" \


### PR DESCRIPTION
Handle DKMS changing to using forward slash '/' when separating the
module name from the module version in `dkms status` output.

Thank you, @albfan and @uhuntu!

Supersedes #627, and a part of #594.