### PR TITLE
uclogic: Switch from hid_is_using_ll_driver to hid_is_usb

### DIFF
--- a/hid-uclogic-params.c
+++ b/hid-uclogic-params.c
@@ -1223,7 +1223,9 @@ int uclogic_params_init(struct uclogic_params *params,
 
 	/* Check arguments */
 	if (params == NULL || hdev == NULL
-#if KERNEL_VERSION(4, 14, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 3, 0) <= LINUX_VERSION_CODE
+	    || !hid_is_usb(hdev)
+#elif KERNEL_VERSION(4, 14, 0) <= LINUX_VERSION_CODE
 	    || !hid_is_using_ll_driver(hdev, &usb_hid_driver)
 #endif
 	   ) {


### PR DESCRIPTION
The `hid_is_using_ll_driver` function was deprecated and has been removed in Linux 6.3 accordingly to https://lore.kernel.org/lkml/20230222101600.y2npwk4hw3ss3j73@mail.corp.redhat.com/
Now wttempt to build existing version results into error:
```
digimend-kernel-drivers-11/hid-uclogic-params.c:1227:17: error: implicit declaration of function ‘hid_is_using_ll_driver’ [-Werror=implicit-function-declaration]
 1227 |             || !hid_is_using_ll_driver(hdev, &usb_hid_driver)
      |                 ^~~~~~~~~~~~~~~~~~~~~~
```
So the call is replaced with `hid_is_usb` for kernel 6.3 or later