### PR TITLE
Use attributes instead of comments for fallthrough

### DIFF
--- a/hid-uclogic-params.c
+++ b/hid-uclogic-params.c
@@ -1365,7 +1365,7 @@ int uclogic_params_init(struct uclogic_params *params,
 			}
 			break;
 		}
-		/* FALLTHROUGH */
+		fallthrough;
 	case VID_PID(USB_VENDOR_ID_HUION,
 		     USB_DEVICE_ID_HUION_TABLET):
 	case VID_PID(USB_VENDOR_ID_HUION,


### PR DESCRIPTION
New linux kernel enforces -Wimplicit-fallthrough=5 which does not accept comments any more:
https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7 This fix introduces attributes for new kernels.

This follows up #616 