### PR TITLE
HID: uclogic: Expose firmware name

### DIFF
--- a/hid-uclogic-params.c
+++ b/hid-uclogic-params.c
@@ -882,6 +882,9 @@ static int uclogic_params_huion_init(struct uclogic_params *params,
 		goto cleanup;
 	}
 
+	/* The firmware is used in userspace as unique identifier */
+	strscpy(hdev->uniq, ver_ptr, sizeof(hdev->uniq));
+
 	/* If this is a transition firmware */
 	if (strcmp(ver_ptr, transition_ver) == 0) {
 		hid_dbg(hdev,


### PR DESCRIPTION
Some vendors reuse the same product ID for different tablets, making it difficult for userspace to figure out which table is connected. While matching the device name has been used in the past by userspace to workaround this limitation, some devices have shown that this is not always a valid approach [1].

However, if userspace could access the firmware version name, it would be possible to know which tablet is actually connected by matching it against a list of known firmware names [2].

This patch exposes the firmware version name in the hid->uniq field.

Link: https://github.com/linuxwacom/libwacom/issues/609  [1]
Link: https://github.com/linuxwacom/libwacom/issues/610  [2]

--------------

Already merged upstream: https://lore.kernel.org/linux-input/20240322100210.107152-1-jose.exposito89@gmail.com/T/