### PR TITLE
Use Rx and Ry for touch strips

### DIFF
--- a/hid-uclogic-rdesc.c
+++ b/hid-uclogic-rdesc.c
@@ -789,7 +789,8 @@ const __u8 uclogic_rdesc_v2_frame_touch_strip_arr[] = {
 	0x95, 0x01,         /*          Report Count (1),           */
 	0x81, 0x02,         /*          Input (Variable),           */
 	0x05, 0x01,         /*          Usage Page (Desktop),       */
-	0x09, 0x38,         /*          Usage (Wheel),              */
+	0x09, 0x33,         /*          Usage (Rx),                 */
+	0x09, 0x34,         /*          Usage (Ry),                 */
 	0x95, 0x01,         /*          Report Count (1),           */
 	0x15, 0x00,         /*          Logical Minimum (0),        */
 	0x25, 0x07,         /*          Logical Maximum (7),        */


### PR DESCRIPTION
Currently, HUION devices use ABS_WHEEL as the usage for touch strips.

There are 2 main issues with this approach:

The first one is that the descriptor for touch rings (uclogic_rdesc_v2_frame_touch_ring_arr) also uses ABS_WHEEL. From user-space it is impossible to know which device sends the events.

The second one is that Wacom uses ABS_RX/ABS_RY to notify events from touch strips and user-space was designed to handle those axes.

Change the usage of touch strips to Rx/Ry to fix both issues.

Link: https://gitlab.freedesktop.org/libinput/libinput/-/issues/989