### PR TITLE
Do not attempt to build modules for kernels without CONFIG_USB_HID

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,6 +1,14 @@
 PACKAGE_NAME="digimend"
 PACKAGE_VERSION="13"
 AUTOINSTALL="yes"
+
+if [ -f $kernel_source_dir/.config ]; then
+    . $kernel_source_dir/.config
+    if [ "${CONFIG_USB_HID:-n}" = "n" ]; then
+        BUILD_EXCLUSIVE_KERNEL="REQUIRES CONFIG_USB_HID"
+    fi
+fi
+
 MAKE[0]="make KVERSION=$kernelver"
 BUILT_MODULE_NAME[0]="hid-kye"
 BUILT_MODULE_NAME[1]="hid-uclogic"


### PR DESCRIPTION
It was forwarded patch from
https://salsa.debian.org/debian/digimend-dkms/-/merge_requests/1

This patch was originally written by Andreas Beckmann <anbe@debian.org>