### PR TITLE
Delegate placement of udev files to pkg-config data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,12 @@ KVERSION := $(shell uname -r)
 KDIR := /lib/modules/$(KVERSION)/build
 PWD := $(shell pwd)
 DESTDIR =
-UDEV_RULES = $(DESTDIR)/lib/udev/rules.d/90-digimend.rules
+UDEVDIR = $(shell pkg-config --variable=udevdir udev)
+UDEV_RULES = $(DESTDIR)$(UDEVDIR)/rules.d/90-digimend.rules
 DEPMOD_CONF = $(DESTDIR)/etc/depmod.d/digimend.conf
 DRACUT_CONF_DIR = $(DESTDIR)/usr/lib/dracut/dracut.conf.d
 DRACUT_CONF = $(DRACUT_CONF_DIR)/90-digimend.conf
-HID_REBIND = $(DESTDIR)/lib/udev/hid-rebind
+HID_REBIND = $(DESTDIR)$(UDEVDIR)/hid-rebind
 DIGIMEND_DEBUG = $(DESTDIR)/usr/sbin/digimend-debug
 XORG_CONF := $(DESTDIR)/usr/share/X11/xorg.conf.d/50-digimend.conf
 PACKAGE_NAME = digimend-kernel-drivers


### PR DESCRIPTION
delegate the exact placement of the udev files to udev.pc (using pkg-config)

This patch was originally written by Chris Hofstaedtler <zeha@debian.org>

FYI:
https://bugs.debian.org/cgi-bin/bugreport.cgi?att=1;bug=1057748;filename=digimend-dkms_11-3-udevdir.patch;msg=5

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1057748