### PR TITLE
Draft: Use HID_QUIRK_MULTI_INPUT 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ website][website].
 Installing
 ----------
 
-Kernel v3.5 or newer is required.
+Kernel v4.18 or newer is required.
 
 Download appropriate files for one of the releases from the [releases
 page][releases]. The "Download ZIP" link on the right of the GitHub page leads

--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -83,15 +83,8 @@ static int uclogic_input_mapping(struct hid_device *hdev,
 	return 0;
 }
 
-#if KERNEL_VERSION(4, 4, 0) > LINUX_VERSION_CODE
-#define RETURN_SUCCESS return
-static void uclogic_input_configured(struct hid_device *hdev,
-		struct hid_input *hi)
-#else
-#define RETURN_SUCCESS return 0
 static int uclogic_input_configured(struct hid_device *hdev,
 		struct hid_input *hi)
-#endif
 {
 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
 	struct uclogic_params *params = &drvdata->params;
@@ -102,7 +95,7 @@ static int uclogic_input_configured(struct hid_device *hdev,
 
 	/* no report associated (HID_QUIRK_MULTI_INPUT not set) */
 	if (!hi->report)
-		RETURN_SUCCESS;
+		return 0;
 
 	/*
 	 * If this is the input corresponding to the pen report
@@ -158,10 +151,8 @@ static int uclogic_input_configured(struct hid_device *hdev,
 		hi->input->name = devm_kasprintf(&hdev->dev, GFP_KERNEL,
 						 "%s %s", hdev->name, suffix);
 
-	RETURN_SUCCESS;
+	return 0;
 }
-#undef RETURN_SUCCESS
-
 
 static int uclogic_probe(struct hid_device *hdev,
 		const struct hid_device_id *id)

--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -162,10 +162,10 @@ static int uclogic_probe(struct hid_device *hdev,
 	bool params_initialized = false;
 
 	/*
-	 * libinput requires the pad interface to be on a different node
-	 * than the pen, so use QUIRK_MULTI_INPUT for all tablets.
+	 * libinput requires the pen interface to be on a different node
+	 * than the pad, dials, touch strips, etc.
 	 */
-	hdev->quirks |= HID_QUIRK_MULTI_INPUT;
+	hdev->quirks |= HID_QUIRK_INPUT_PER_APP;
 	hdev->quirks |= HID_QUIRK_HIDINPUT_FORCE;
 #ifdef HID_QUIRK_NO_EMPTY_INPUT
 	hdev->quirks |= HID_QUIRK_NO_EMPTY_INPUT;


### PR DESCRIPTION
Userspace requires the pad buttons, touch-rings, touch-strips, dials and similar devices to be in the same event node.
    
Use HID_QUIRK_MULTI_INPUT to expose only 2 event nodes: one for the pen and another one for the pad devices.

---------------------------------

You'll notice that, in regular HUION devices, there are 3 interfaces:

- Keyboard: I don't know if this one is used by any device, but (and least in my H640P) it is garbage from the firmware
- Keypad: Pad buttons, touch-rings, touch-strips, dials, etc
- Unnamed: The pen

On XP-Pen:

- Keypad: Pad buttons, touch-rings, touch-strips, dials, etc
- Unnamed 1: The pen
- Unnamed 2: Mouse. It is the circular area inside the dial in devices like the [Deco Pro SW](https://www.storexppen.es/buy/deco-pro-sw.html). (Which by the way stopped working in working with "recent" libinput).

Mark as draft because:

- The naming of the interfaces is broken because `uclogic_input_configured` doesn't receive the hid-report anymore. I need to investigate if it is possible to fix it, but I run out of time.
  As a side effect of the naming changes, libwacom matches will break and custon user config might break as well.

- `EV_MSC` reports are not disabled anymore for touch-rings.  I can't test it but, if there is any kind of support in userspace, this change could break it:
   https://github.com/DIGImend/digimend-kernel-drivers/blob/master/hid-uclogic-core.c#L122-L127

I'm not sure about merging this. Unless the benefit (i.e., dials, touch-rings, etc work auto-magically) is grater than the possible issues caused, we should handle this PR carefully.

cc @spbnick @tequeter @whot 