### PR TITLE
Update to Linux 6.12

### DIFF
--- a/hid-kye.c
+++ b/hid-kye.c
@@ -579,7 +579,7 @@ static __u8 *kye_consumer_control_fixup(struct hid_device *hdev, __u8 *rdesc,
 	return rdesc;
 }
 
-static __u8 *kye_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+static const __u8 *kye_report_fixup(struct hid_device *hdev, __u8 *rdesc,
 		unsigned int *rsize)
 {
 	switch (hdev->product) {

--- a/hid-kye.c
+++ b/hid-kye.c
@@ -18,6 +18,8 @@
 #include <linux/hid.h>
 #include <linux/module.h>
 
+#include <linux/version.h>
+
 #include "hid-ids.h"
 
 /* Original EasyPen i405X report descriptor size */
@@ -579,8 +581,13 @@ static __u8 *kye_consumer_control_fixup(struct hid_device *hdev, __u8 *rdesc,
 	return rdesc;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+static __u8 *kye_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+		unsigned int *rsize)
+#else
 static const __u8 *kye_report_fixup(struct hid_device *hdev, __u8 *rdesc,
 		unsigned int *rsize)
+#endif
 {
 	switch (hdev->product) {
 	case USB_DEVICE_ID_KYE_ERGO_525V:

--- a/hid-polostar.c
+++ b/hid-polostar.c
@@ -16,6 +16,7 @@
 #include <linux/hid.h>
 #include <linux/module.h>
 #include <linux/usb.h>
+#include <linux/version.h>
 
 #include "hid-ids.h"
 
@@ -149,8 +150,13 @@ static __u8 pt1001_rdesc_fixed[] = {
 	0xC0,               /*  End Collection                          */
 };
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+static __u8 *polostar_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+				   unsigned int *rsize)
+#else
 static const __u8 *polostar_report_fixup(struct hid_device *hdev, __u8 *rdesc,
 				   unsigned int *rsize)
+#endif
 {
 	struct usb_interface *iface = to_usb_interface(hdev->dev.parent);
 	__u8 iface_num = iface->cur_altsetting->desc.bInterfaceNumber;

--- a/hid-polostar.c
+++ b/hid-polostar.c
@@ -149,7 +149,7 @@ static __u8 pt1001_rdesc_fixed[] = {
 	0xC0,               /*  End Collection                          */
 };
 
-static __u8 *polostar_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+static const __u8 *polostar_report_fixup(struct hid_device *hdev, __u8 *rdesc,
 				   unsigned int *rsize)
 {
 	struct usb_interface *iface = to_usb_interface(hdev->dev.parent);

--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -53,7 +53,7 @@ static void uclogic_inrange_timeout(struct timer_list *t)
 	input_sync(input);
 }
 
-static __u8 *uclogic_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+static const __u8 *uclogic_report_fixup(struct hid_device *hdev, __u8 *rdesc,
 					unsigned int *rsize)
 {
 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);

--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -53,8 +53,13 @@ static void uclogic_inrange_timeout(struct timer_list *t)
 	input_sync(input);
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+static __u8 *uclogic_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+				unsigned int *rsize)
+#else
 static const __u8 *uclogic_report_fixup(struct hid_device *hdev, __u8 *rdesc,
 					unsigned int *rsize)
+#endif
 {
 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
 

--- a/hid-uclogic-params.c
+++ b/hid-uclogic-params.c
@@ -19,7 +19,7 @@
 #include "hid-ids.h"
 #include <linux/ctype.h>
 #include <linux/string.h>
-#include <asm/unaligned.h>
+#include <linux/unaligned.h>
 
 #include <linux/version.h>
 

--- a/hid-uclogic-params.c
+++ b/hid-uclogic-params.c
@@ -19,9 +19,14 @@
 #include "hid-ids.h"
 #include <linux/ctype.h>
 #include <linux/string.h>
-#include <linux/unaligned.h>
-
 #include <linux/version.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+#include <asm/unaligned.h>
+#else
+#include <linux/unaligned.h>
+#endif
+
 
 /**
  * uclogic_params_pen_inrange_to_str() - Convert a pen in-range reporting type

--- a/hid-uclogic-rdesc.c
+++ b/hid-uclogic-rdesc.c
@@ -16,7 +16,7 @@
 
 #include "hid-uclogic-rdesc.h"
 #include <linux/slab.h>
-#include <asm/unaligned.h>
+#include <linux/unaligned.h>
 
 /* Fixed WP4030U report descriptor */
 __u8 uclogic_rdesc_wp4030u_fixed_arr[] = {

--- a/hid-uclogic-rdesc.c
+++ b/hid-uclogic-rdesc.c
@@ -16,7 +16,13 @@
 
 #include "hid-uclogic-rdesc.h"
 #include <linux/slab.h>
+#include <linux/version.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+#include <asm/unaligned.h>
+#else
 #include <linux/unaligned.h>
+#endif
 
 /* Fixed WP4030U report descriptor */
 __u8 uclogic_rdesc_wp4030u_fixed_arr[] = {

--- a/hid-viewsonic.c
+++ b/hid-viewsonic.c
@@ -16,6 +16,7 @@
 #include <linux/hid.h>
 #include <linux/module.h>
 #include <linux/usb.h>
+#include <linux/version.h>
 
 #include "hid-ids.h"
 
@@ -71,8 +72,13 @@ static __u8 pd1011_rdesc_fixed[] = {
 	0xC0                    /*  End Collection                      */
 };
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+static __u8 *viewsonic_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+				    unsigned int *rsize)
+#else
 static const __u8 *viewsonic_report_fixup(struct hid_device *hdev, __u8 *rdesc,
 				    unsigned int *rsize)
+#endif
 {
 	switch (hdev->product) {
 	case USB_DEVICE_ID_VIEWSONIC_PD1011:

--- a/hid-viewsonic.c
+++ b/hid-viewsonic.c
@@ -71,7 +71,7 @@ static __u8 pd1011_rdesc_fixed[] = {
 	0xC0                    /*  End Collection                      */
 };
 
-static __u8 *viewsonic_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+static const __u8 *viewsonic_report_fixup(struct hid_device *hdev, __u8 *rdesc,
 				    unsigned int *rsize)
 {
 	switch (hdev->product) {


### PR DESCRIPTION
This patch allows the digimend kernel drivers to build on Linux kernel 6.12.
The reason it failed before is because of a header rename from `<asm/unaligned.h>` to `<linux/unaligned.h>`. And the struct of the hid_driver changed requiring a const pointer for the `report_fixup`