### PR TITLE
fix: Rename `del_timer_sync()` to `timer_delete_sync()`

### DIFF
--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -491,7 +491,7 @@ static void uclogic_remove(struct hid_device *hdev)
 {
 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
 
-	del_timer_sync(&drvdata->inrange_timer);
+	timer_delete_sync(&drvdata->inrange_timer);
 	hid_hw_stop(hdev);
 	kfree(drvdata->desc_ptr);
 	uclogic_params_cleanup(&drvdata->params);

--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -25,6 +25,14 @@
 #include "compat.h"
 #include <linux/version.h>
 
+/* 
+ * Linux kernel >= 6.1.84 no longer includes wrapper for deprecated 
+ * del_timer_sync
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 84)
+#define del_timer_sync timer_delete_sync
+#endif
+
 /**
  * uclogic_inrange_timeout - handle pen in-range state timeout.
  * Emulate input events normally generated when pen goes out of range for
@@ -491,7 +499,7 @@ static void uclogic_remove(struct hid_device *hdev)
 {
 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
 
-	timer_delete_sync(&drvdata->inrange_timer);
+	del_timer_sync(&drvdata->inrange_timer);
 	hid_hw_stop(hdev);
 	kfree(drvdata->desc_ptr);
 	uclogic_params_cleanup(&drvdata->params);


### PR DESCRIPTION
The timer function `del_timer_sync()` was renamed to `timer_delete_sync()` in November 2022 (<https://lkml.org/lkml/2022/11/23/1482>), and a wrapper for it was recently removed. This prevents DIGImend from compiling on Linux 6.15.0 and later.

The issue can be solved by just replacing the name. Validated on Arch Linux (Linux 6.15.2).