### PR TITLE
Fix del_timer_sync(&drvdata->inrange_timer); for timer_shutdown_sync(&drvdata->inrange_timer);

### DIFF
--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -491,7 +491,7 @@ static void uclogic_remove(struct hid_device *hdev)
 {
 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
 
-	del_timer_sync(&drvdata->inrange_timer);
+	timer_shutdown_sync(&drvdata->inrange_timer);
 	hid_hw_stop(hdev);
 	kfree(drvdata->desc_ptr);
 	uclogic_params_cleanup(&drvdata->params);


### PR DESCRIPTION
Hi,

I make this merge request because I had this issue when I tried to compile it on Linux 6.16.6

```make
hid-uclogic-core.c: In function ‘uclogic_remove’:
hid-uclogic-core.c:494:9: error: implicit declaration of function ‘del_timer_sync’ [-Wimplicit-function-declaration]
    494 |         del_timer_sync(&drvdata->inrange_timer);
        |         ^~~~~~~~~~~~~~
```

So I changed ``del_timer_sync(&drvdata->inrange_timer);`` for ``timer_shutdown_sync(&drvdata->inrange_timer);``