### PR TITLE
add preprocessor compatibility alias (timer_delete_sync)

### DIFF
--- a/hid-uclogic-core.c
+++ b/hid-uclogic-core.c
@@ -25,6 +25,10 @@
 #include "compat.h"
 #include <linux/version.h>
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 84)
+#define timer_delete_sync del_timer_sync
+#endif
+
 /**
  * uclogic_inrange_timeout - handle pen in-range state timeout.
  * Emulate input events normally generated when pen goes out of range for
@@ -491,7 +495,7 @@ static void uclogic_remove(struct hid_device *hdev)
 {
 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
 
-	del_timer_sync(&drvdata->inrange_timer);
+	timer_delete_sync(&drvdata->inrange_timer);
 	hid_hw_stop(hdev);
 	kfree(drvdata->desc_ptr);
 	uclogic_params_cleanup(&drvdata->params);


### PR DESCRIPTION
add conditional preprocessor compatibility alias based on kernel version for backwards compability.
The patch is now delivered with Archlinux User Repo https://aur.archlinux.org/packages/digimend-kernel-drivers-dkms.

The Archlinux User Repo git-version https://aur.archlinux.org/packages/digimend-kernel-drivers-dkms-git does now temporarly point to the downstream branch [arkadesOrg:hotfix](https://github.com/arkadesOrg/digimend-kernel-drivers/tree/hotfix)